### PR TITLE
#90: CORS 설정 및 로그인 응답 JSON 구조로 변경

### DIFF
--- a/api/src/main/java/com/kernel/app/config/CorsMvcConfig.java
+++ b/api/src/main/java/com/kernel/app/config/CorsMvcConfig.java
@@ -10,7 +10,9 @@ public class CorsMvcConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000");
+                .allowedOrigins("http://localhost:3000", "http://localhost:5173") // 3000: React (CRA), 5173: Vite (Vue, React 지원)
+                .allowCredentials(true)           // 쿠키 허용(refreshToken)
+                .exposedHeaders("Authorization"); // 응답 헤더 노출 허용(accessToken)
     }
 
 }

--- a/api/src/main/java/com/kernel/app/config/SecurityConfig.java
+++ b/api/src/main/java/com/kernel/app/config/SecurityConfig.java
@@ -2,10 +2,14 @@ package com.kernel.app.config;
 
 import com.kernel.app.exception.handler.JwtAccessDeniedHandler;
 import com.kernel.app.exception.handler.JwtAuthenticationEntryPoint;
-import com.kernel.app.jwt.*;
-
+import com.kernel.app.jwt.CustomLoginFilter;
+import com.kernel.app.jwt.CustomLogoutFilter;
+import com.kernel.app.jwt.JwtFilter;
+import com.kernel.app.jwt.JwtProperties;
+import com.kernel.app.jwt.JwtTokenProvider;
 import com.kernel.app.repository.RefreshRepository;
-import com.kernel.common.global.enums.UserType;
+import java.util.Arrays;
+import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,8 +26,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
-
-import java.util.Collections;
 
 @Configuration
 @EnableWebSecurity
@@ -155,7 +157,7 @@ public class SecurityConfig {
     private CorsConfigurationSource corsConfigurationSource() {
         return request -> {
             CorsConfiguration config = new CorsConfiguration();
-            config.setAllowedOrigins(Collections.singletonList("http://localhost:3000"));
+            config.setAllowedOrigins(Arrays.asList("http://localhost:3000", "http://localhost:5173")); // 3000: React (CRA), 5173: Vite (Vue, React 지원)
             config.setAllowedMethods(Collections.singletonList("*"));
             config.setAllowedHeaders(Collections.singletonList("*"));
             config.setAllowCredentials(true);

--- a/api/src/main/java/com/kernel/app/dto/CustomerUserDetails.java
+++ b/api/src/main/java/com/kernel/app/dto/CustomerUserDetails.java
@@ -65,4 +65,6 @@ public class CustomerUserDetails implements UserDetails, AuthenticatedUser {
     public boolean isEnabled() {
         return true;
     }
+
+    public String getName() { return customer.getUserName(); }
 }

--- a/api/src/main/java/com/kernel/app/dto/ManagerUserDetails.java
+++ b/api/src/main/java/com/kernel/app/dto/ManagerUserDetails.java
@@ -65,4 +65,6 @@ public class ManagerUserDetails implements UserDetails, AuthenticatedUser {
     public boolean isEnabled() {
         return true;
     }
+
+    public String getName() { return manager.getUserName(); }
 }

--- a/api/src/main/java/com/kernel/app/jwt/CustomLoginFilter.java
+++ b/api/src/main/java/com/kernel/app/jwt/CustomLoginFilter.java
@@ -13,6 +13,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.HashMap;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -74,6 +75,7 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
         String phone;
         String role;
         String userId;
+        String name;
 
         // role 권한에서 추출
         role = authentication.getAuthorities().stream()
@@ -87,16 +89,19 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
                 CustomerUserDetails userDetails = (CustomerUserDetails) authentication.getPrincipal();
                 phone = userDetails.getUsername();
                 userId = userDetails.getUserId();
+                name = userDetails.getName();
             }
             case "manager" -> {
                 ManagerUserDetails userDetails = (ManagerUserDetails) authentication.getPrincipal();
                 phone = userDetails.getUsername();
                 userId = userDetails.getUserId();
+                name = userDetails.getName();
             }
             case "admin" -> {
                 AdminUserDetails userDetails = (AdminUserDetails) authentication.getPrincipal();
                 phone = userDetails.getUsername();
                 userId = userDetails.getUserId();
+                name = null;
             }
             default -> throw new IllegalStateException("Unsupported user type: " + userType);
         }
@@ -112,7 +117,11 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
             response.setStatus(HttpStatus.OK.value());
             response.setContentType("application/json;charset=UTF-8");
 
-            ApiResponse<Void> successResponse = new ApiResponse<>(true, "로그인이 완료되었습니다.", null);
+            // Map 생성해서 name 담기
+            Map<String, Object> bodyMap = new HashMap<>();
+            bodyMap.put("userName", name);
+
+            ApiResponse<Map<String, Object>> successResponse = new ApiResponse<>(true, "로그인이 완료되었습니다.", bodyMap);
             objectMapper.writeValue(response.getWriter(), successResponse);
 
             log.info("User logged in successfully: {}", phone);


### PR DESCRIPTION
### 작업내용
- CORS 설정에 Vite 개발 포트(http://localhost:5173) 추가
- allowCredentials(true) 및 exposedHeaders("Authorization") 설정 적용
- 로그인 성공 응답의 body를 문자열 → JSON 객체 { userName: string } 구조로 변경
   - 로그인 응답 예시:  
  (※ `userName`은 수요자, 매니저인 경우에만 포함됨)

  ```json
  {
    "success": true,
    "message": "로그인이 완료되었습니다.",
    "body": {
      "userName": "홍길동"
    }
  }

### 관련 이슈
- Close #90  
