### PR TITLE
#92: @AuthenticationPrincipal 사용을 위한 인증 구조 개선

### DIFF
--- a/api/src/main/java/com/kernel/app/jwt/CustomAuthenticationProvider.java
+++ b/api/src/main/java/com/kernel/app/jwt/CustomAuthenticationProvider.java
@@ -1,0 +1,39 @@
+package com.kernel.app.jwt;
+
+import com.kernel.app.service.CustomUserDetailsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationProvider implements AuthenticationProvider {
+
+    private final CustomUserDetailsService customUserDetailsService;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        String rawPrincipal = authentication.getPrincipal().toString();
+        String password = authentication.getCredentials().toString();
+
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername(rawPrincipal);
+
+        if (!passwordEncoder.matches(password, userDetails.getPassword())) {
+            throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
+        }
+
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/api/src/main/java/com/kernel/app/jwt/CustomLoginFilter.java
+++ b/api/src/main/java/com/kernel/app/jwt/CustomLoginFilter.java
@@ -1,9 +1,9 @@
 package com.kernel.app.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.kernel.app.dto.AdminUserDetails;
-import com.kernel.app.dto.CustomerUserDetails;
-import com.kernel.app.dto.ManagerUserDetails;
+import com.kernel.common.global.security.AdminUserDetails;
+import com.kernel.common.global.security.CustomerUserDetails;
+import com.kernel.common.global.security.ManagerUserDetails;
 import com.kernel.app.entity.Refresh;
 import com.kernel.app.exception.ErrorCode;
 import com.kernel.app.exception.dto.ErrorResponse;

--- a/api/src/main/java/com/kernel/app/jwt/JwtFilter.java
+++ b/api/src/main/java/com/kernel/app/jwt/JwtFilter.java
@@ -1,8 +1,8 @@
 package com.kernel.app.jwt;
 
-import com.kernel.app.dto.AdminUserDetails;
-import com.kernel.app.dto.CustomerUserDetails;
-import com.kernel.app.dto.ManagerUserDetails;
+import com.kernel.common.global.security.AdminUserDetails;
+import com.kernel.common.global.security.CustomerUserDetails;
+import com.kernel.common.global.security.ManagerUserDetails;
 import com.kernel.common.admin.entity.Admin;
 import com.kernel.common.manager.entity.Manager;
 import com.kernel.common.customer.entity.Customer;

--- a/api/src/main/java/com/kernel/app/jwt/JwtFilter.java
+++ b/api/src/main/java/com/kernel/app/jwt/JwtFilter.java
@@ -29,6 +29,18 @@ public class JwtFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
+        // 토큰이 없는 로그인(login)과 회원가입(signup) 요청은 JWT 필터에서 제외
+        String uri = request.getRequestURI();
+        if (uri.equals("/api/customers/auth/login")
+            || uri.equals("/api/managers/auth/login")
+            || uri.equals("/api/admins/auth/login")
+            || uri.equals("/api/customers/auth/signup")
+            || uri.equals("/api/managers/auth/signup")) {
+
+            filterChain.doFilter(request, response); // JWT 검사 없이 통과
+            return;
+        }
+        
         // Bearer 접두사 제거하여 실제 토큰 추출
         String accessToken = jwtTokenProvider.resolveToken(request);
 

--- a/api/src/main/java/com/kernel/app/jwt/JwtTokenProvider.java
+++ b/api/src/main/java/com/kernel/app/jwt/JwtTokenProvider.java
@@ -25,7 +25,7 @@ public class JwtTokenProvider {
     public String resolveToken(HttpServletRequest request) {
         String bearer = request.getHeader("Authorization");
         if (bearer != null && bearer.startsWith("Bearer ")) {
-            return bearer.substring(7);
+            return bearer.substring(7).trim();
         }
         return null;
     }

--- a/api/src/main/java/com/kernel/app/service/CustomUserDetailsService.java
+++ b/api/src/main/java/com/kernel/app/service/CustomUserDetailsService.java
@@ -1,9 +1,9 @@
 package com.kernel.app.service;
 
 
-import com.kernel.app.dto.CustomerUserDetails;
-import com.kernel.app.dto.ManagerUserDetails;
-import com.kernel.app.dto.AdminUserDetails;
+import com.kernel.common.global.security.CustomerUserDetails;
+import com.kernel.common.global.security.ManagerUserDetails;
+import com.kernel.common.global.security.AdminUserDetails;
 import com.kernel.app.repository.AdminAuthRepository;
 import com.kernel.app.repository.CustomerAuthRepository;
 import com.kernel.app.repository.ManagerAuthRepository;

--- a/common/src/main/java/com/kernel/common/global/security/AdminUserDetails.java
+++ b/common/src/main/java/com/kernel/common/global/security/AdminUserDetails.java
@@ -1,13 +1,12 @@
-package com.kernel.app.dto;
+package com.kernel.common.global.security;
 
 import com.kernel.common.admin.entity.Admin;
 import com.kernel.common.global.AuthenticatedUser;
+import java.util.ArrayList;
+import java.util.Collection;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
-
-import java.util.ArrayList;
-import java.util.Collection;
 
 @RequiredArgsConstructor
 public class AdminUserDetails implements UserDetails, AuthenticatedUser {
@@ -65,4 +64,6 @@ public class AdminUserDetails implements UserDetails, AuthenticatedUser {
     public boolean isEnabled() {
         return true;
     }
+
+    public Long getAdminId() { return admin.getAdminId(); }
 }

--- a/common/src/main/java/com/kernel/common/global/security/CustomerUserDetails.java
+++ b/common/src/main/java/com/kernel/common/global/security/CustomerUserDetails.java
@@ -1,4 +1,4 @@
-package com.kernel.app.dto;
+package com.kernel.common.global.security;
 
 import com.kernel.common.customer.entity.Customer;
 import com.kernel.common.global.AuthenticatedUser;
@@ -67,4 +67,6 @@ public class CustomerUserDetails implements UserDetails, AuthenticatedUser {
     }
 
     public String getName() { return customer.getUserName(); }
+
+    public Long getCustomerId() { return customer.getCustomerId(); }
 }

--- a/common/src/main/java/com/kernel/common/global/security/ManagerUserDetails.java
+++ b/common/src/main/java/com/kernel/common/global/security/ManagerUserDetails.java
@@ -1,13 +1,12 @@
-package com.kernel.app.dto;
+package com.kernel.common.global.security;
 
-import com.kernel.common.manager.entity.Manager;
 import com.kernel.common.global.AuthenticatedUser;
+import com.kernel.common.manager.entity.Manager;
+import java.util.ArrayList;
+import java.util.Collection;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
-
-import java.util.ArrayList;
-import java.util.Collection;
 
 @RequiredArgsConstructor
 public class ManagerUserDetails implements UserDetails, AuthenticatedUser {
@@ -67,4 +66,6 @@ public class ManagerUserDetails implements UserDetails, AuthenticatedUser {
     }
 
     public String getName() { return manager.getUserName(); }
+
+    public Long getManagerId() { return manager.getManagerId(); }
 }

--- a/common/src/main/java/com/kernel/common/manager/controller/CleaningLogController.java
+++ b/common/src/main/java/com/kernel/common/manager/controller/CleaningLogController.java
@@ -1,6 +1,7 @@
 package com.kernel.common.manager.controller;
 
 import com.kernel.common.global.entity.ApiResponse;
+import com.kernel.common.global.security.ManagerUserDetails;
 import com.kernel.common.manager.dto.request.CleaningLogCheckInReqDTO;
 import com.kernel.common.manager.dto.request.CleaningLogCheckOutReqDTO;
 import com.kernel.common.manager.dto.response.CleaningLogCheckInRspDTO;
@@ -9,6 +10,8 @@ import com.kernel.common.manager.service.CleaningLogService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -30,11 +33,11 @@ public class CleaningLogController {
      */
     @PostMapping("/{reservation_id}/check-in")
     public ResponseEntity<ApiResponse<CleaningLogCheckInRspDTO>> checkIn(
+        @AuthenticationPrincipal ManagerUserDetails manager,
         @PathVariable("reservation_id") Long reservationId,
         @Valid @RequestBody CleaningLogCheckInReqDTO requestDTO
     ) {
-        // TODO: @AuthenticationPrincipal 사용이 가능해지면 1L이 아닌 실제 id 넘길 예정
-        CleaningLogCheckInRspDTO responseDTO = cleaningLogService.checkIn(1L, reservationId, requestDTO);
+        CleaningLogCheckInRspDTO responseDTO = cleaningLogService.checkIn(manager.getManagerId(), reservationId, requestDTO);
         return ResponseEntity.ok(new ApiResponse<>(true, "체크인 성공", responseDTO));
     }
 
@@ -46,11 +49,11 @@ public class CleaningLogController {
      */
     @PostMapping("/{reservation_id}/check-out")
     public ResponseEntity<ApiResponse<CleaningLogCheckOutRspDTO>> checkOut(
+        @AuthenticationPrincipal ManagerUserDetails manager,
         @PathVariable("reservation_id") Long reservationId,
         @Valid @RequestBody CleaningLogCheckOutReqDTO requestDTO
     ) {
-        // TODO: @AuthenticationPrincipal 사용이 가능해지면 1L이 아닌 실제 id 넘길 예정
-        CleaningLogCheckOutRspDTO responseDTO = cleaningLogService.checkOut(1L, reservationId, requestDTO);
+        CleaningLogCheckOutRspDTO responseDTO = cleaningLogService.checkOut(manager.getManagerId(), reservationId, requestDTO);
         return ResponseEntity.ok(new ApiResponse<>(true, "체크아웃 성공", responseDTO));
     }
 }


### PR DESCRIPTION
### 작업내용

- 기존 인증 로직에서 principal이 문자열(username)로 설정되던 문제 개선
- `CustomAuthenticationProvider` 구현  
  - 인증 성공 시 `UserDetails` 구현체를 principal로 설정하도록 수정
- `SecurityConfig`에 커스텀 `AuthenticationProvider` 등록
- 컨트롤러에서 `@AuthenticationPrincipal`을 통해 사용자 정보 주입 가능하도록 구조 개선
- `ManagerUserDetails`, `CustomerUserDetails`, `AdminUserDetails` 각각에 사용자 ID 반환 메서드 추가
  - `getManagerId()`, `getCustomerId()`, `getAdminId()` 등

---

### 리뷰요청
- `@AuthenticationPrincipal ManagerUserDetails manager`처럼 사용하기 위해,  기존에 `api` 모듈에 있던 `ManagerUserDetails`, `CustomerUserDetails`, `AdminUserDetails`를 `common` 모듈의 `global.security`로 이동했습니다. 해당 위치 구조 괜찮은지 확인 부탁드립니다.
- 각각의 UserDetails 클래스에 추가한 ID 반환 메서드를 현재는 `getManagerId()`, `getCustomerId()`, `getAdminId()` 형태로 사용 중인데,  
  이 메서드를 `getId()`로 통일하는 것이 나을지, 아니면 지금처럼 유지할지에 대한 의견 부탁드립니다.

---

### 관련 이슈
- Close #92
