### PR TITLE
#92: 로그아웃 응답 구조 개선 및 관리자 API URL 수정

### DIFF
--- a/api/src/main/java/com/kernel/app/config/SecurityConfig.java
+++ b/api/src/main/java/com/kernel/app/config/SecurityConfig.java
@@ -75,7 +75,7 @@ public class SecurityConfig {
             .addFilterBefore(new CustomLogoutFilter(jwtTokenProvider, refreshRepository), LogoutFilter.class)
             .logout(logout -> logout
                     .logoutUrl("/api/logout")
-                    .logoutSuccessUrl("/")
+//                    .logoutSuccessUrl("/") // 권한에 따라 로그아웃 후 리다이렉트 되는 경로가 달라 프론트에서 처리
                     .deleteCookies("refresh"));
 
         return http.build();
@@ -137,14 +137,14 @@ public class SecurityConfig {
         applyCommonSecurityConfig(http);
 
         CustomLoginFilter loginFilter = new CustomLoginFilter(jwtTokenProvider, authenticationManager(), refreshRepository, jwtProperties);
-        loginFilter.setFilterProcessesUrl("/api/admins/auth/login");
+        loginFilter.setFilterProcessesUrl("/api/admin/auth/login");
 
         http
-            .securityMatcher("/api/admins/**", "/api/admins/auth/login")
+            .securityMatcher("/api/admin/**", "/api/admin/auth/login")
             .authorizeHttpRequests(auth -> auth
-                    .requestMatchers("/api/admins/**").permitAll()) // TODO 테스트용
-                   /* .requestMatchers("/api/admins/auth/login", "/api/admins/auth/signup").permitAll()
-                    .requestMatchers("/api/admins/**").hasRole(UserType.ADMIN.name())) */ //TODO 테스트용이하게 막아둠, 배포시 주석 제거
+                    .requestMatchers("/api/admin/**").permitAll()) // TODO 테스트용
+                   /* .requestMatchers("/api/admin/auth/login", "/api/admin/auth/signup").permitAll()
+                    .requestMatchers("/api/admin/**").hasRole(UserType.ADMIN.name())) */ //TODO 테스트용이하게 막아둠, 배포시 주석 제거
             .addFilterBefore(new JwtFilter(jwtTokenProvider), CustomLoginFilter.class)
             .addFilterAt(loginFilter, UsernamePasswordAuthenticationFilter.class)
             .addFilterBefore(new CustomLogoutFilter(jwtTokenProvider, refreshRepository), LogoutFilter.class);

--- a/api/src/main/java/com/kernel/app/controller/AdminAuthController.java
+++ b/api/src/main/java/com/kernel/app/controller/AdminAuthController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/admins/auth")
+@RequestMapping("/api/admin/auth")
 @RequiredArgsConstructor
 public class AdminAuthController {
 

--- a/api/src/main/java/com/kernel/app/jwt/CustomLogoutFilter.java
+++ b/api/src/main/java/com/kernel/app/jwt/CustomLogoutFilter.java
@@ -59,6 +59,18 @@ public class CustomLogoutFilter extends GenericFilterBean {
         expiredCookie .setPath("/");
         response.addCookie(expiredCookie );
 
+        // JSON 응답 작성
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        String responseJson = """
+        {
+          "success": true,
+          "message": "로그아웃 성공",
+          "body": null
+        }
+        """;
+        response.getWriter().write(responseJson);
+
         response.setStatus(HttpServletResponse.SC_OK);
     }
 

--- a/api/src/main/java/com/kernel/app/jwt/JwtFilter.java
+++ b/api/src/main/java/com/kernel/app/jwt/JwtFilter.java
@@ -33,7 +33,7 @@ public class JwtFilter extends OncePerRequestFilter {
         String uri = request.getRequestURI();
         if (uri.equals("/api/customers/auth/login")
             || uri.equals("/api/managers/auth/login")
-            || uri.equals("/api/admins/auth/login")
+            || uri.equals("/api/admin/auth/login")
             || uri.equals("/api/customers/auth/signup")
             || uri.equals("/api/managers/auth/signup")) {
 


### PR DESCRIPTION
### 작업내용
- 관리자 API 엔드포인트 /admins → /admin으로 변경
- 로그아웃 응답 구조를 프론트 처리에 맞게 정리
- redirect 응답 제거 (프론트에서 navigate 처리 예정)

### 관련 이슈
- Close #92 