### PR TITLE
#109: [매니저] 상태값에 따른 접근 제한 로직 추가

### DIFF
--- a/api/src/main/java/com/kernel/app/exception/handler/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/kernel/app/exception/handler/GlobalExceptionHandler.java
@@ -56,7 +56,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
         log.warn("Access denied: {}", e.getMessage());
-        ErrorResponse errorResponse = new ErrorResponse(ErrorCode.ACCESS_DENIED);
+        String message = (e.getMessage() != null && !e.getMessage().isBlank())
+            ? e.getMessage()
+            : ErrorCode.ACCESS_DENIED.getMessage();
+        ErrorResponse errorResponse = new ErrorResponse(ErrorCode.ACCESS_DENIED.getCode(), message);
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorResponse);
     }
 

--- a/api/src/main/java/com/kernel/app/jwt/CustomLoginFilter.java
+++ b/api/src/main/java/com/kernel/app/jwt/CustomLoginFilter.java
@@ -1,6 +1,7 @@
 package com.kernel.app.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kernel.common.global.enums.UserStatus;
 import com.kernel.common.global.security.AdminUserDetails;
 import com.kernel.common.global.security.CustomerUserDetails;
 import com.kernel.common.global.security.ManagerUserDetails;
@@ -76,6 +77,7 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
         String role;
         Long userId;
         String name;
+        UserStatus status;
 
         // role 권한에서 추출
         role = authentication.getAuthorities().stream()
@@ -90,18 +92,21 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
                 phone = userDetails.getUsername();
                 userId = userDetails.getUserId();
                 name = userDetails.getName();
+                status = userDetails.getStatus();
             }
             case "manager" -> {
                 ManagerUserDetails userDetails = (ManagerUserDetails) authentication.getPrincipal();
                 phone = userDetails.getUsername();
                 userId = userDetails.getUserId();
                 name = userDetails.getName();
+                status = userDetails.getStatus();
             }
             case "admin" -> {
                 AdminUserDetails userDetails = (AdminUserDetails) authentication.getPrincipal();
                 phone = userDetails.getUsername();
                 userId = userDetails.getUserId();
                 name = null;
+                status = userDetails.getStatus();
             }
             default -> throw new IllegalStateException("Unsupported user type: " + userType);
         }
@@ -120,6 +125,7 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
             // Map 생성해서 name 담기
             Map<String, Object> bodyMap = new HashMap<>();
             bodyMap.put("userName", name);
+            bodyMap.put("status", status);
 
             ApiResponse<Map<String, Object>> successResponse = new ApiResponse<>(true, "로그인이 완료되었습니다.", bodyMap);
             objectMapper.writeValue(response.getWriter(), successResponse);

--- a/api/src/main/java/com/kernel/app/service/CustomUserDetailsService.java
+++ b/api/src/main/java/com/kernel/app/service/CustomUserDetailsService.java
@@ -1,13 +1,12 @@
 package com.kernel.app.service;
 
-
-import com.kernel.common.global.security.CustomerUserDetails;
-import com.kernel.common.global.security.ManagerUserDetails;
-import com.kernel.common.global.security.AdminUserDetails;
 import com.kernel.app.repository.AdminAuthRepository;
 import com.kernel.app.repository.CustomerAuthRepository;
 import com.kernel.app.repository.ManagerAuthRepository;
 import com.kernel.common.global.enums.UserStatus;
+import com.kernel.common.global.security.AdminUserDetails;
+import com.kernel.common.global.security.CustomerUserDetails;
+import com.kernel.common.global.security.ManagerUserDetails;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -38,7 +37,7 @@ public class CustomUserDetailsService implements UserDetailsService {
             case "customer" -> customerRepository.findByPhone(phone)
                     .map(CustomerUserDetails::new)
                     .orElseThrow(() -> new UsernameNotFoundException("Customer not found"));
-            case "manager" -> managerRepository.findByPhoneAndStatusIn(phone, List.of(UserStatus.ACTIVE, UserStatus.TERMINATION_PENDING))
+            case "manager" -> managerRepository.findByPhoneAndStatusIn(phone, List.of(UserStatus.ACTIVE, UserStatus.PENDING, UserStatus.REJECTED, UserStatus.TERMINATION_PENDING))
                     .map(ManagerUserDetails::new)
                     .orElseThrow(() -> new UsernameNotFoundException("Manager not found"));
             case "admin" -> adminRepository.findByPhone(phone)

--- a/common/src/main/java/com/kernel/common/global/AuthenticatedUser.java
+++ b/common/src/main/java/com/kernel/common/global/AuthenticatedUser.java
@@ -1,5 +1,6 @@
 package com.kernel.common.global;
 
+import com.kernel.common.global.enums.UserStatus;
 import org.springframework.security.core.GrantedAuthority;
 
 import java.util.Collection;
@@ -7,5 +8,6 @@ import java.util.Collection;
 public interface AuthenticatedUser {
     String getUsername();
     Long getUserId();
+    UserStatus getStatus();
     Collection<? extends GrantedAuthority> getAuthorities();
 }

--- a/common/src/main/java/com/kernel/common/global/security/AdminUserDetails.java
+++ b/common/src/main/java/com/kernel/common/global/security/AdminUserDetails.java
@@ -2,6 +2,7 @@ package com.kernel.common.global.security;
 
 import com.kernel.common.admin.entity.Admin;
 import com.kernel.common.global.AuthenticatedUser;
+import com.kernel.common.global.enums.UserStatus;
 import java.util.ArrayList;
 import java.util.Collection;
 import lombok.RequiredArgsConstructor;
@@ -65,5 +66,5 @@ public class AdminUserDetails implements UserDetails, AuthenticatedUser {
         return true;
     }
 
-    public Long getAdminId() { return admin.getAdminId(); }
+    public UserStatus getStatus() { return admin.getStatus(); }
 }

--- a/common/src/main/java/com/kernel/common/global/security/CustomerUserDetails.java
+++ b/common/src/main/java/com/kernel/common/global/security/CustomerUserDetails.java
@@ -2,6 +2,7 @@ package com.kernel.common.global.security;
 
 import com.kernel.common.customer.entity.Customer;
 import com.kernel.common.global.AuthenticatedUser;
+import com.kernel.common.global.enums.UserStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -67,4 +68,6 @@ public class CustomerUserDetails implements UserDetails, AuthenticatedUser {
     }
 
     public String getName() { return customer.getUserName(); }
+
+    public UserStatus getStatus() { return customer.getStatus(); }
 }

--- a/common/src/main/java/com/kernel/common/global/security/ManagerUserDetails.java
+++ b/common/src/main/java/com/kernel/common/global/security/ManagerUserDetails.java
@@ -1,6 +1,7 @@
 package com.kernel.common.global.security;
 
 import com.kernel.common.global.AuthenticatedUser;
+import com.kernel.common.global.enums.UserStatus;
 import com.kernel.common.manager.entity.Manager;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -67,5 +68,5 @@ public class ManagerUserDetails implements UserDetails, AuthenticatedUser {
 
     public String getName() { return manager.getUserName(); }
 
-    public Long getManagerId() { return manager.getManagerId(); }
+    public UserStatus getStatus() { return manager.getStatus(); }
 }

--- a/common/src/main/java/com/kernel/common/manager/controller/CleaningLogController.java
+++ b/common/src/main/java/com/kernel/common/manager/controller/CleaningLogController.java
@@ -1,7 +1,8 @@
 package com.kernel.common.manager.controller;
 
+import com.kernel.common.global.AuthenticatedUser;
 import com.kernel.common.global.entity.ApiResponse;
-import com.kernel.common.global.security.ManagerUserDetails;
+import com.kernel.common.global.enums.UserStatus;
 import com.kernel.common.manager.dto.request.CleaningLogCheckInReqDTO;
 import com.kernel.common.manager.dto.request.CleaningLogCheckOutReqDTO;
 import com.kernel.common.manager.dto.response.CleaningLogCheckInRspDTO;
@@ -10,8 +11,9 @@ import com.kernel.common.manager.service.CleaningLogService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,8 +21,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/managers/reservations")
 @RequiredArgsConstructor
+@RequestMapping("/api/managers/reservations")
 public class CleaningLogController {
 
     private final CleaningLogService cleaningLogService;
@@ -34,11 +36,16 @@ public class CleaningLogController {
      */
     @PostMapping("/{reservation-id}/check-in")
     public ResponseEntity<ApiResponse<CleaningLogCheckInRspDTO>> checkIn(
-        @AuthenticationPrincipal ManagerUserDetails manager,
+        @AuthenticationPrincipal AuthenticatedUser manager,
         @PathVariable("reservation-id") Long reservationId,
         @Valid @RequestBody CleaningLogCheckInReqDTO requestDTO
     ) {
-        CleaningLogCheckInRspDTO responseDTO = cleaningLogService.checkIn(manager.getManagerId(), reservationId, requestDTO);
+        if (!UserStatus.ACTIVE.equals(manager.getStatus())) {
+            throw new AccessDeniedException(
+                "죄송합니다. 현재 계정 상태에서는 해당 요청을 처리할 수 없습니다. (상태: " + manager.getStatus().getLabel() + ")"
+            );
+        }
+        CleaningLogCheckInRspDTO responseDTO = cleaningLogService.checkIn(manager.getUserId(), reservationId, requestDTO);
         return ResponseEntity.ok(new ApiResponse<>(true, "체크인 성공", responseDTO));
     }
 
@@ -48,20 +55,18 @@ public class CleaningLogController {
      * @param requestDTO
      * @return 체크아웃 정보를 담은 응답
      */
-    /**
-     * 체크아웃
-     * @param manager 매니저
-     * @param reservationId 예약ID
-     * @param requestDTO 체크아웃 요청 정보
-     * @return
-     */
-    @PostMapping("/{reservation-id}/check-out")
+    @PreAuthorize("manager.status == 'ACTIVE'")
     public ResponseEntity<ApiResponse<CleaningLogCheckOutRspDTO>> checkOut(
-        @AuthenticationPrincipal ManagerUserDetails manager,
+        @AuthenticationPrincipal AuthenticatedUser manager,
         @PathVariable("reservation-id") Long reservationId,
         @Valid @RequestBody CleaningLogCheckOutReqDTO requestDTO
     ) {
-        CleaningLogCheckOutRspDTO responseDTO = cleaningLogService.checkOut(manager.getManagerId(), reservationId, requestDTO);
+        if (!UserStatus.ACTIVE.equals(manager.getStatus())) {
+            throw new AccessDeniedException(
+                "죄송합니다. 현재 계정 상태에서는 해당 요청을 처리할 수 없습니다. (상태: " + manager.getStatus().getLabel() + ")"
+            );
+        }
+        CleaningLogCheckOutRspDTO responseDTO = cleaningLogService.checkOut(manager.getUserId(), reservationId, requestDTO);
         return ResponseEntity.ok(new ApiResponse<>(true, "체크아웃 성공", responseDTO));
     }
 }

--- a/common/src/main/java/com/kernel/common/manager/controller/ManagerInquiryController.java
+++ b/common/src/main/java/com/kernel/common/manager/controller/ManagerInquiryController.java
@@ -3,7 +3,7 @@ package com.kernel.common.manager.controller;
 
 import com.kernel.common.global.AuthenticatedUser;
 import com.kernel.common.global.entity.ApiResponse;
-import com.kernel.common.global.security.ManagerUserDetails;
+import com.kernel.common.global.enums.UserStatus;
 import com.kernel.common.manager.dto.request.ManagerInquiryCreateReqDTO;
 import com.kernel.common.manager.dto.request.ManagerInquirySearchCondDTO;
 import com.kernel.common.manager.dto.request.ManagerInquiryUpdateReqDTO;
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.AccessDeniedException;
 
 @RestController
 @RequiredArgsConstructor
@@ -46,6 +47,15 @@ public class ManagerInquiryController {
         @ModelAttribute ManagerInquirySearchCondDTO searchCondDTO,
         Pageable pageable
     ) {
+        if (    !UserStatus.ACTIVE.equals(manager.getStatus())               // 활성
+             || !UserStatus.PENDING.equals(manager.getStatus())              // 대기
+             || !UserStatus.REJECTED.equals(manager.getStatus())             // 매니저 승인 거절
+             || !UserStatus.TERMINATION_PENDING.equals(manager.getStatus())  // 매니저 계약 해지 대기
+        ) {
+            throw new AccessDeniedException(
+                "죄송합니다. 현재 계정 상태에서는 해당 요청을 처리할 수 없습니다. (상태: " + manager.getStatus().getLabel() + ")"
+            );
+        }
         Page<ManagerInquirySummaryRspDTO> summaryRspDTOPage
             = managerInquiryService.searchManagerinquiriesWithPaging(manager.getUserId(), searchCondDTO, pageable);
         return ResponseEntity.ok(new ApiResponse<>(true, "매니저 상담 게시글 목록 조회 성공", summaryRspDTOPage));
@@ -62,6 +72,15 @@ public class ManagerInquiryController {
         @AuthenticationPrincipal AuthenticatedUser manager,
         @PathVariable("inquiry-id") Long inquiryId
     ) {
+        if (   !UserStatus.ACTIVE.equals(manager.getStatus())               // 활성
+            || !UserStatus.PENDING.equals(manager.getStatus())              // 대기
+            || !UserStatus.REJECTED.equals(manager.getStatus())             // 매니저 승인 거절
+            || !UserStatus.TERMINATION_PENDING.equals(manager.getStatus())  // 매니저 계약 해지 대기
+        ) {
+            throw new AccessDeniedException(
+                "죄송합니다. 현재 계정 상태에서는 해당 요청을 처리할 수 없습니다. (상태: " + manager.getStatus().getLabel() + ")"
+            );
+        }
         ManagerInquiryRspDTO rspDTO = managerInquiryService.getManagerInquiry(manager.getUserId(), inquiryId);
         return ResponseEntity.ok(new ApiResponse<>(true, "매니저 문의사항 상세 조회 성공", rspDTO));
     }
@@ -77,6 +96,15 @@ public class ManagerInquiryController {
         @AuthenticationPrincipal AuthenticatedUser manager,
         @Valid @RequestBody ManagerInquiryCreateReqDTO requestDTO
     ) {
+        if (   !UserStatus.ACTIVE.equals(manager.getStatus())               // 활성
+            || !UserStatus.PENDING.equals(manager.getStatus())              // 대기
+            || !UserStatus.REJECTED.equals(manager.getStatus())             // 매니저 승인 거절
+            || !UserStatus.TERMINATION_PENDING.equals(manager.getStatus())  // 매니저 계약 해지 대기
+        ) {
+            throw new AccessDeniedException(
+                "죄송합니다. 현재 계정 상태에서는 해당 요청을 처리할 수 없습니다. (상태: " + manager.getStatus().getLabel() + ")"
+            );
+        }
         ManagerInquirySummaryRspDTO summaryRspDTO = managerInquiryService.createManagerInquiry(manager.getUserId(), requestDTO);
         return ResponseEntity.ok(new ApiResponse<>(true, "매니저 문의사항 등록 성공", summaryRspDTO));
     }
@@ -94,6 +122,15 @@ public class ManagerInquiryController {
         @PathVariable("inquiry-id") Long inquiryId,
         @Valid @RequestBody ManagerInquiryUpdateReqDTO requestDTO
     ) {
+        if (   !UserStatus.ACTIVE.equals(manager.getStatus())               // 활성
+            || !UserStatus.PENDING.equals(manager.getStatus())              // 대기
+            || !UserStatus.REJECTED.equals(manager.getStatus())             // 매니저 승인 거절
+            || !UserStatus.TERMINATION_PENDING.equals(manager.getStatus())  // 매니저 계약 해지 대기
+        ) {
+            throw new AccessDeniedException(
+                "죄송합니다. 현재 계정 상태에서는 해당 요청을 처리할 수 없습니다. (상태: " + manager.getStatus().getLabel() + ")"
+            );
+        }
         ManagerInquirySummaryRspDTO summaryRspDTO = managerInquiryService.updateManagerInquiry(manager.getUserId(), inquiryId, requestDTO);
         return ResponseEntity.ok(new ApiResponse<>(true, "매니저 문의사항 수정 성공", summaryRspDTO));
     }
@@ -109,6 +146,15 @@ public class ManagerInquiryController {
         @AuthenticationPrincipal AuthenticatedUser manager,
         @PathVariable("inquiry-id") Long inquiryId
     ) {
+        if (   !UserStatus.ACTIVE.equals(manager.getStatus())               // 활성
+            || !UserStatus.PENDING.equals(manager.getStatus())              // 대기
+            || !UserStatus.REJECTED.equals(manager.getStatus())             // 매니저 승인 거절
+            || !UserStatus.TERMINATION_PENDING.equals(manager.getStatus())  // 매니저 계약 해지 대기
+        ) {
+            throw new AccessDeniedException(
+                "죄송합니다. 현재 계정 상태에서는 해당 요청을 처리할 수 없습니다. (상태: " + manager.getStatus().getLabel() + ")"
+            );
+        }
         managerInquiryService.deleteManagerInquiry(manager.getUserId(), inquiryId);
         return ResponseEntity.ok(new ApiResponse<>(true, "매니저 문의사항 삭제 성공", null));
     }

--- a/common/src/main/java/com/kernel/common/manager/controller/ManagerReviewController.java
+++ b/common/src/main/java/com/kernel/common/manager/controller/ManagerReviewController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -36,6 +37,7 @@ public class ManagerReviewController {
      * @return 검색 조건에 따른 매니저 리뷰 목록을 응답 (페이징 포함)
      */
     @GetMapping
+    @PreAuthorize("manager.status == 'ACTIVE'")
     public ResponseEntity<ApiResponse<Page<ManagerReviewSummaryRspDTO>>> searchManagerReviews(
         @AuthenticationPrincipal AuthenticatedUser manager,
         @ModelAttribute ManagerReviewSearchCondDTO searchCondDTO,
@@ -54,6 +56,7 @@ public class ManagerReviewController {
      * @return 작성된 리뷰 정보를 담은 응답
      */
     @PostMapping("/{reservation-id}")
+    @PreAuthorize("manager.status == 'ACTIVE'")
     public ResponseEntity<ApiResponse<ManagerReviewRspDTO>> createManagerReview(
         @AuthenticationPrincipal AuthenticatedUser manager,
         @PathVariable("reservation-id") Long reservationId,

--- a/common/src/main/java/com/kernel/common/reservation/controller/ManagerReservationController.java
+++ b/common/src/main/java/com/kernel/common/reservation/controller/ManagerReservationController.java
@@ -2,6 +2,7 @@ package com.kernel.common.reservation.controller;
 
 import com.kernel.common.global.AuthenticatedUser;
 import com.kernel.common.global.entity.ApiResponse;
+import com.kernel.common.global.enums.UserStatus;
 import com.kernel.common.global.security.ManagerUserDetails;
 import com.kernel.common.reservation.dto.request.ManagerReservationSearchCondDTO;
 import com.kernel.common.reservation.dto.response.ManagerReservationRspDTO;
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -38,6 +40,11 @@ public class ManagerReservationController {
         @ModelAttribute ManagerReservationSearchCondDTO searchCondDTO,
         Pageable pageable
     ) {
+        if (!UserStatus.ACTIVE.equals(manager.getStatus())) {
+            throw new AccessDeniedException(
+                "죄송합니다. 현재 계정 상태에서는 해당 요청을 처리할 수 없습니다. (상태: " + manager.getStatus().getLabel() + ")"
+            );
+        }
         Page<ManagerReservationSummaryRspDTO> responseDTOPage
             = reservationService.searchManagerReservationsWithPaging(manager.getUserId(), searchCondDTO, pageable);
         return ResponseEntity.ok(new ApiResponse<>(true, "매니저 예약 목록 조회 성공", responseDTOPage));
@@ -54,6 +61,11 @@ public class ManagerReservationController {
         @AuthenticationPrincipal AuthenticatedUser manager,
         @PathVariable("reservation-id") Long reservationId
     ) {
+        if (!UserStatus.ACTIVE.equals(manager.getStatus())) {
+            throw new AccessDeniedException(
+                "죄송합니다. 현재 계정 상태에서는 해당 요청을 처리할 수 없습니다. (상태: " + manager.getStatus().getLabel() + ")"
+            );
+        }
         ManagerReservationRspDTO responseDTO = reservationService.getManagerReservation(manager.getUserId(), reservationId);
         return ResponseEntity.ok(new ApiResponse<>(true, "매니저 예약 상세 조회 성공", responseDTO));
     }


### PR DESCRIPTION
### 작업내역
- AuthenticatedUser.java, CustomerUserDetails.java, ManagerUserDetails.java, AdminUserDetails.java에 getStatus() 메서드 추가
- CustomLoginFilter.java: 로그인 성공 시 응답 body에 status 필드 추가
- GlobalExceptionHandler.java: AccessDeniedException 처리 시 e.getMessage()가 존재하면 해당 메시지 반환하도록 개선
- 매니저 관련 Controller에 계정 상태에 따른 접근 제한 로직 추가

### 리뷰 요청
- 계정 상태에 따른 권한 제어 방식은 여러 가지가 있었으나, 프론트에서는 메뉴 노출을 상태에 따라 제어하고, 백엔드에서는 각 컨트롤러 메서드에서 상태를 직접 체크하는 방식으로 구현하였습니다.
- 추후에는 @PreAuthorize 또는 @CheckManagerStatus(allowed = {UserStatus.ACTIVE})와 같은 커스텀 어노테이션을 활용하여 AOP 방식으로 분리하는 리팩토링을 계획하고 있습니다.

### 관련 이슈
- Close #109