### PR TITLE
Feat/#107

### DIFF
--- a/common/src/main/java/com/kernel/common/customer/controller/CustomerInquiryController.java
+++ b/common/src/main/java/com/kernel/common/customer/controller/CustomerInquiryController.java
@@ -31,7 +31,7 @@ public class CustomerInquiryController {
     @GetMapping
     public ResponseEntity<ApiResponse<Page<CustomerInquiryRspDTO>>> searchCustomerInquiries(
             @RequestParam(required = false) String keyword,
-            @PageableDefault(size = 3) Pageable pageable // TODO 페이지 전역 설정 확인
+            @PageableDefault(size = 10) Pageable pageable
             // TODO @AuthenticationPrincipal AuthenticatedUser customer
     ) {
         Page<CustomerInquiryRspDTO> rspDTOPage =

--- a/common/src/main/java/com/kernel/common/global/enums/UserStatus.java
+++ b/common/src/main/java/com/kernel/common/global/enums/UserStatus.java
@@ -10,6 +10,7 @@ public enum UserStatus {
     DELETED("탈퇴"),                   // 탈퇴
     PENDING("승인대기"),                // 매니저 승인 대기
     REJECTED("승인거절"),               // 매니저 승인 거절
+    MATCHING("매칭 중"),                // 예약 매칭 중
     TERMINATION_PENDING("계약해지대기"), // 매니저 계약 해지 대기
     TERMINATED("계약해지");             // 매니저 계약 해지
 

--- a/common/src/main/java/com/kernel/common/manager/repository/ManagerRepository.java
+++ b/common/src/main/java/com/kernel/common/manager/repository/ManagerRepository.java
@@ -2,7 +2,6 @@ package com.kernel.common.manager.repository;
 
 import com.kernel.common.global.enums.UserStatus;
 import com.kernel.common.manager.entity.Manager;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/common/src/main/java/com/kernel/common/matching/dto/ManagerMatchingRspDTO.java
+++ b/common/src/main/java/com/kernel/common/matching/dto/ManagerMatchingRspDTO.java
@@ -1,0 +1,40 @@
+package com.kernel.common.matching.dto;
+
+import com.kernel.common.global.enums.FeedbackType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Builder
+@Getter
+public class ManagerMatchingRspDTO {
+
+    // 매니저ID
+    private Long managerId;
+
+    // 매니저이름
+    private String managerName;
+
+    // 매니저 평균 별점
+    private BigDecimal averageRating;
+
+    // 매니저 리뷰 수
+    private Integer reviewCount;
+
+    // 매니저 프로필 사진
+    private Long profileImageId;
+
+    // 매니저 한줄 소개
+    private String bio;
+
+    // 매니저 좋아요/아쉬워요 여부
+    private FeedbackType feedbackType;
+
+    // 최근 예약 일자
+    private LocalDate recentReservationDate;
+
+
+
+}

--- a/common/src/main/java/com/kernel/common/matching/dto/MatchingManagerMapper.java
+++ b/common/src/main/java/com/kernel/common/matching/dto/MatchingManagerMapper.java
@@ -1,0 +1,26 @@
+package com.kernel.common.matching.dto;
+
+import com.kernel.common.manager.entity.Manager;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class MatchingManagerMapper {
+
+    public List<ManagerMatchingRspDTO> toRspDTOList(List<Manager> managers) {
+        return managers.stream()
+                .map(manager -> ManagerMatchingRspDTO.builder()
+                        .managerId(manager.getManagerId())
+                        .managerName(manager.getUserName())
+                        .averageRating(manager.getAverageRating())
+                        .reviewCount(manager.getReviewCount())
+                        .profileImageId(manager.getProfileImageId())
+                        .bio(manager.getBio())
+                        //.feedbackType(manager.)
+                        //.recentReservationDate()
+                        .build()
+                ).toList();
+    }
+}
+

--- a/common/src/main/java/com/kernel/common/matching/repository/MatchingManagerRepository.java
+++ b/common/src/main/java/com/kernel/common/matching/repository/MatchingManagerRepository.java
@@ -1,0 +1,20 @@
+package com.kernel.common.matching.repository;
+
+import com.kernel.common.global.enums.UserStatus;
+import com.kernel.common.manager.entity.Manager;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MatchingManagerRepository extends JpaRepository<Manager, Long> {
+
+    // 활성 상태 매니저만 조회 TODO 매칭 알고리즘 구현 후 지우기
+    List<Manager> findByStatus(UserStatus userStatus);
+
+    // 매니저 조회 for 수요자 예약 확정
+    Optional<Manager> findByManagerId(Long selectedManagerId);
+
+    // 매칭 매니저 리스트 조회
+    List<Manager> findByManagerIdIn(List<Long> matchedManagerIds);
+}

--- a/common/src/main/java/com/kernel/common/matching/service/MatchingManagerService.java
+++ b/common/src/main/java/com/kernel/common/matching/service/MatchingManagerService.java
@@ -1,0 +1,16 @@
+package com.kernel.common.matching.service;
+
+import com.kernel.common.matching.dto.ManagerMatchingRspDTO;
+import com.kernel.common.reservation.dto.request.CustomerReservationReqDTO;
+import com.kernel.common.reservation.dto.request.ReservationConfirmReqDTO;
+
+import java.util.List;
+
+public interface MatchingManagerService {
+
+    // 매칭 매니저 조회
+    List<ManagerMatchingRspDTO> getMatchingManagers(CustomerReservationReqDTO reservationReqDTO);
+
+    // 매칭 매니저 리스트 상태 변경
+    void updateMatchingManagersStatus(ReservationConfirmReqDTO confirmReqDTO);
+}

--- a/common/src/main/java/com/kernel/common/matching/service/MatchingManagerServiceImpl.java
+++ b/common/src/main/java/com/kernel/common/matching/service/MatchingManagerServiceImpl.java
@@ -1,0 +1,59 @@
+package com.kernel.common.matching.service;
+
+import com.kernel.common.global.enums.UserStatus;
+import com.kernel.common.manager.entity.Manager;
+import com.kernel.common.matching.dto.ManagerMatchingRspDTO;
+import com.kernel.common.matching.dto.MatchingManagerMapper;
+import com.kernel.common.matching.repository.MatchingManagerRepository;
+import com.kernel.common.reservation.dto.request.CustomerReservationReqDTO;
+import com.kernel.common.reservation.dto.request.ReservationConfirmReqDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MatchingManagerServiceImpl implements MatchingManagerService {
+
+    private final MatchingManagerRepository matchingRepository;
+    private final MatchingManagerMapper matchingMapper;
+
+    /**
+     * 매니저 매칭 리스트 조회
+     * @param reservationReqDTO 예약요청DTO
+     * @return 매니저 매칭 리스트
+     */
+    @Override
+    @Transactional
+    public List<ManagerMatchingRspDTO> getMatchingManagers(CustomerReservationReqDTO reservationReqDTO) {
+        // TODO 매칭 알고리즘 구현
+        List<Manager> matchedManagers = matchingRepository.findByStatus(UserStatus.ACTIVE);
+
+        // 매칭 매니저 상태값 변경
+        matchedManagers.forEach(manager -> {
+            manager.updateStatus(UserStatus.MATCHING);
+        });
+
+        return matchingMapper.toRspDTOList(matchedManagers);
+    }
+
+    /**
+     * 예약 확정 후 매니저 상태 변경
+     * @param confirmReqDTO 예약 확정 DTO
+     */
+    @Override
+    @Transactional
+    public void updateMatchingManagersStatus(ReservationConfirmReqDTO confirmReqDTO) {
+
+        // 매칭 매니저리스트 조회
+        List<Manager> matchedManagers = matchingRepository.findByManagerIdIn(confirmReqDTO.getMatchedManagerIds());
+
+        // 매칭 매니저 상태값 변경
+        matchedManagers.forEach(manager -> {
+            manager.updateStatus(UserStatus.ACTIVE);
+        });
+
+    }
+}

--- a/common/src/main/java/com/kernel/common/repository/ServiceCategoryRepository.java
+++ b/common/src/main/java/com/kernel/common/repository/ServiceCategoryRepository.java
@@ -1,7 +1,8 @@
 package com.kernel.common.repository;
 
 import com.kernel.common.reservation.entity.ServiceCategory;
+import com.kernel.common.reservation.repository.CustomServiceCategoryRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ServiceCategoryRepository extends JpaRepository<ServiceCategory, Long> {
+public interface ServiceCategoryRepository extends JpaRepository<ServiceCategory, Long>, CustomServiceCategoryRepository {
 }

--- a/common/src/main/java/com/kernel/common/reservation/controller/CustomerReservationController.java
+++ b/common/src/main/java/com/kernel/common/reservation/controller/CustomerReservationController.java
@@ -1,11 +1,16 @@
 package com.kernel.common.reservation.controller;
 
 import com.kernel.common.global.entity.ApiResponse;
+import com.kernel.common.matching.dto.ManagerMatchingRspDTO;
+import com.kernel.common.matching.service.MatchingManagerService;
 import com.kernel.common.reservation.dto.request.CustomerReservationCancelReqDTO;
-import com.kernel.common.reservation.dto.response.CustomerReservationDetailRspDTO;
-import com.kernel.common.reservation.dto.response.CustomerReservationRspDTO;
+import com.kernel.common.reservation.dto.request.CustomerReservationReqDTO;
+import com.kernel.common.reservation.dto.request.ReservationConfirmReqDTO;
+import com.kernel.common.reservation.dto.response.*;
 import com.kernel.common.reservation.enums.ReservationStatus;
 import com.kernel.common.reservation.service.CustomerReservationService;
+import com.kernel.common.reservation.service.ServiceCategoryService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,12 +18,70 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/customers/reservations")
 @RequiredArgsConstructor
 public class CustomerReservationController {
 
     private final CustomerReservationService customerReservationService;
+    private final MatchingManagerService matchingService;
+    private final ServiceCategoryService serviceCategoryService;
+
+    /**
+     * 예약 요청
+     * @param customerId 수요자ID
+     * @param reservationReqDTO 수요자 예약 요청 DTO
+     * @return 예약 요청 내용 + 매칭 매니저 리스트
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<ReservationMatchedRspDTO>> requestCustomerReservation(
+            @RequestParam(required = false) Long customerId, // TODO 테스트용
+            // TODO @AuthenticationPrincipal AuthenticatedUser customer
+            @Valid @RequestBody CustomerReservationReqDTO reservationReqDTO
+    ){
+        // 예약 요청 저장
+        ReservationRspDTO requestedReservation = customerReservationService.requestCustomerReservation(customerId, reservationReqDTO);
+
+        // 예약 요청 서비스 카테고리 조회
+        ServiceCategoryTreeDTO requestCategory = serviceCategoryService.getRequestServiceCategory(reservationReqDTO.getServiceCategoryId());
+
+        // 매칭 매니저 조회 및 매칭된 매니저 상태 변경 ACTIVE -> MATCHING
+        List<ManagerMatchingRspDTO> matchedManagers = matchingService.getMatchingManagers(reservationReqDTO);
+
+        // 예약ID + 매칭 매니저 리스트
+        ReservationMatchedRspDTO result = ReservationMatchedRspDTO.builder()
+                                        .reservation(requestedReservation)
+                                        .requestCategory(requestCategory)
+                                        .matchedManagers(matchedManagers)
+                                        .build();
+
+        return ResponseEntity.ok(new ApiResponse<>(true, "수요자 예약 요청 성공", result));
+    }
+
+    /**
+     * 예약 확정
+     * @param reservationId 예약ID
+     * @param customerId 수요자ID
+     * @param confirmReqDTO 예약확정 요청DTO
+     * @return 확정한 예약 정보
+     */
+    @PatchMapping("/{reservation-id}/confirm")
+    public ResponseEntity<ApiResponse<CustomerReservationRspDTO>> confirmCustomerReservation(
+            @PathVariable("reservation-id") Long reservationId,
+            @RequestParam Long customerId, // TODO 테스트용
+            // TODO @AuthenticationPrincipal AuthenticatedUser customer
+            @Valid @RequestBody ReservationConfirmReqDTO confirmReqDTO
+    ){
+        // 예약 확정
+        CustomerReservationRspDTO rspDTO = customerReservationService.confirmCustomerReservation(customerId, reservationId, confirmReqDTO);
+
+        // 매니저 매칭 리스트 상태 변경 MATCHING -> ACTIVE
+        matchingService.updateMatchingManagersStatus(confirmReqDTO);
+
+        return ResponseEntity.ok(new ApiResponse<>(true, "수요자 예약 확정 성공", rspDTO));
+    }
 
     /**
      * 예약 내역 조회
@@ -31,7 +94,7 @@ public class CustomerReservationController {
     public ResponseEntity<ApiResponse<Page<CustomerReservationRspDTO>>> getCustomerReservations(
             @RequestParam(required = false) ReservationStatus status,
             @RequestParam Long customerId, // TODO 테스트용
-            @PageableDefault(size = 3 ) Pageable pageable //TODO size 수정
+            @PageableDefault(size = 10) Pageable pageable
             // TODO @AuthenticationPrincipal AuthenticatedUser customer
     ) {
         Page<CustomerReservationRspDTO> rspDTOPage
@@ -63,7 +126,7 @@ public class CustomerReservationController {
      * @param customerId 수요자ID
      * @param cancelReqDTO 예약 취소 요청 DTO
      */
-    @PatchMapping("{reservation_id}")
+    @PatchMapping("/{reservation_id}/cancel")
     public ResponseEntity<ApiResponse<Void>> cancelReservationByCustomer(
             @RequestParam Long customerId, // TODO 테스트용
             @RequestBody CustomerReservationCancelReqDTO cancelReqDTO

--- a/common/src/main/java/com/kernel/common/reservation/controller/ServiceCategoryController.java
+++ b/common/src/main/java/com/kernel/common/reservation/controller/ServiceCategoryController.java
@@ -1,0 +1,32 @@
+package com.kernel.common.reservation.controller;
+
+import com.kernel.common.global.entity.ApiResponse;
+import com.kernel.common.reservation.dto.response.ServiceCategoryTreeDTO;
+import com.kernel.common.reservation.service.ServiceCategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/customers/reservations")
+public class ServiceCategoryController {
+
+    private final ServiceCategoryService serviceCategoryService;
+
+    /**
+     * 서비스 카테고리 조회
+     * @return 서비스 카테고리 tree
+     */
+    @GetMapping("/categories")
+    public ResponseEntity<ApiResponse<List<ServiceCategoryTreeDTO>>> getServiceCategory(){
+
+        List<ServiceCategoryTreeDTO> rspDTOList = serviceCategoryService.getServiceCategoryTree();
+
+        return ResponseEntity.ok(new ApiResponse<>(true, "서비스 카테고리 조회 성공", rspDTOList));
+    }
+}

--- a/common/src/main/java/com/kernel/common/reservation/dto/mapper/ReservationMapper.java
+++ b/common/src/main/java/com/kernel/common/reservation/dto/mapper/ReservationMapper.java
@@ -1,0 +1,48 @@
+package com.kernel.common.reservation.dto.mapper;
+
+import com.kernel.common.customer.entity.Customer;
+import com.kernel.common.reservation.dto.request.CustomerReservationReqDTO;
+import com.kernel.common.reservation.dto.response.ReservationRspDTO;
+import com.kernel.common.reservation.entity.Reservation;
+import com.kernel.common.reservation.entity.ServiceCategory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ReservationMapper {
+
+    // CustomerReservationReqDTO -> Reservation
+    public Reservation toEntity(Long customerId, CustomerReservationReqDTO reservationReqDTO) {
+        return Reservation.builder()
+                .serviceCategory(ServiceCategory.builder().serviceId(reservationReqDTO.getServiceCategoryId()).build())
+                .customer(Customer.builder().customerId(customerId).build())
+                .zipcode(reservationReqDTO.getZipcode())
+                .roadAddress(reservationReqDTO.getRoadAddress())
+                .detailAddress(reservationReqDTO.getDetailAddress())
+                .latitude(reservationReqDTO.getLatitude())
+                .longitude(reservationReqDTO.getLongitude())
+                .requestDate(reservationReqDTO.getRequestDate())
+                .startTime(reservationReqDTO.getStartTime())
+                .turnaround(reservationReqDTO.getTurnaround())
+                .price(reservationReqDTO.getPrice())
+                .memo(reservationReqDTO.getMemo())
+                .build();
+    }
+
+    // Reservation -> ReservationRspDTO
+    public ReservationRspDTO toRspDTO(Reservation reservation) {
+        return ReservationRspDTO.builder()
+                .reservationId(reservation.getReservationId())
+                .serviceCategoryId(reservation.getServiceCategory().getServiceId())
+                .zipcode(reservation.getZipcode())
+                .roadAddress(reservation.getRoadAddress())
+                .detailAddress(reservation.getDetailAddress())
+                .latitude(reservation.getLatitude())
+                .longitude(reservation.getLongitude())
+                .requestDate(reservation.getRequestDate())
+                .startTime(reservation.getStartTime())
+                .turnaround(reservation.getTurnaround())
+                .price(reservation.getPrice())
+                .memo(reservation.getMemo())
+                .build();
+    }
+}

--- a/common/src/main/java/com/kernel/common/reservation/dto/request/CustomerReservationReqDTO.java
+++ b/common/src/main/java/com/kernel/common/reservation/dto/request/CustomerReservationReqDTO.java
@@ -1,0 +1,56 @@
+package com.kernel.common.reservation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+public class CustomerReservationReqDTO {
+
+    // 서비스ID
+    @NotNull(message = "서비스 유형을 선택해주세요.")
+    private Long serviceCategoryId;
+
+    // 우편번호
+    @NotBlank(message = "우편번호를 입력해주세요.")
+    private String zipcode;
+
+    // 도로명 주소
+    @NotBlank(message = "도로명 주소를 입력해주세요.")
+    private String roadAddress;
+
+    // 상세 주소
+    @NotBlank(message = "상세주소를 입력해주세요.")
+    private String detailAddress;
+
+    // 위도
+    @NotNull(message = "주소를 입력해주세요.")
+    private BigDecimal latitude;
+
+    // 경도
+    @NotNull(message = "주소를 입력해주세요.")
+    private BigDecimal longitude;
+
+    // 청소 요청 날짜
+    @NotNull(message = "서비스 요청 날짜를 입력해주세요.")
+    private LocalDate requestDate;
+
+    // 청소 시작 희망 시간
+    @NotNull(message = "서비스 희망 시간을 입력해주세요.")
+    private LocalTime startTime;
+
+    // 소요 시간
+    @NotNull(message = "서비스를 선택해주세요.")
+    private Integer turnaround;
+
+    // 예약 금액
+    @NotNull(message = "서비스를 선택해주세요.")
+    private Integer price;
+
+    // 고객 요청사항 메모
+    private String memo;
+}

--- a/common/src/main/java/com/kernel/common/reservation/dto/request/ReservationConfirmReqDTO.java
+++ b/common/src/main/java/com/kernel/common/reservation/dto/request/ReservationConfirmReqDTO.java
@@ -1,0 +1,17 @@
+package com.kernel.common.reservation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ReservationConfirmReqDTO {
+
+    // 선택한 매니저 ID
+    @NotNull(message = "매니저를 선택해주세요.")
+    private Long selectedManagerId;
+
+    // 매칭 매니저 리스트 ID
+    private List<Long> matchedManagerIds;
+}

--- a/common/src/main/java/com/kernel/common/reservation/dto/response/CustomerReservationDetailRspDTO.java
+++ b/common/src/main/java/com/kernel/common/reservation/dto/response/CustomerReservationDetailRspDTO.java
@@ -12,7 +12,7 @@ import java.time.LocalTime;
 import java.util.List;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class CustomerReservationDetailRspDTO {
 
@@ -43,7 +43,7 @@ public class CustomerReservationDetailRspDTO {
     // 서비스 종류(대분류)
     private String serviceName;
 
-    // 추가
+    // 추가 서비스
     private List<ExtraServiceRspDTO> extraServices;
 
     // 매니저 이름
@@ -60,9 +60,5 @@ public class CustomerReservationDetailRspDTO {
 
     // 결제 수단 //TODO 가격관리 정의 후 수정
     //private String payment;
-
-
-
-
 
 }

--- a/common/src/main/java/com/kernel/common/reservation/dto/response/CustomerReservationRspDTO.java
+++ b/common/src/main/java/com/kernel/common/reservation/dto/response/CustomerReservationRspDTO.java
@@ -8,8 +8,8 @@ import java.time.LocalTime;
 
 @Getter
 @Builder
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class CustomerReservationRspDTO {
 
     // 예약 ID

--- a/common/src/main/java/com/kernel/common/reservation/dto/response/ReservationMatchedRspDTO.java
+++ b/common/src/main/java/com/kernel/common/reservation/dto/response/ReservationMatchedRspDTO.java
@@ -1,0 +1,21 @@
+package com.kernel.common.reservation.dto.response;
+
+import com.kernel.common.matching.dto.ManagerMatchingRspDTO;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class ReservationMatchedRspDTO {
+
+    // 예약ID
+    private ReservationRspDTO reservation;
+
+    // 요청 서비스 카테고리
+    private ServiceCategoryTreeDTO requestCategory;
+
+    // 매칭 매니저 리스트
+    private List<ManagerMatchingRspDTO> matchedManagers;
+}

--- a/common/src/main/java/com/kernel/common/reservation/dto/response/ReservationRspDTO.java
+++ b/common/src/main/java/com/kernel/common/reservation/dto/response/ReservationRspDTO.java
@@ -1,0 +1,49 @@
+package com.kernel.common.reservation.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Builder
+@Getter
+public class ReservationRspDTO {
+
+    // 예약 ID
+    private Long reservationId;
+
+    // 서비스 ID
+    private Long serviceCategoryId;
+
+    // 우편번호
+    private String zipcode;
+
+    // 도로명 주소
+    private String roadAddress;
+
+    // 상세 주소
+    private String detailAddress;
+
+    // 위도
+    private BigDecimal latitude;
+
+    // 경도
+    private BigDecimal longitude;
+
+    // 청소 요청 날짜
+    private LocalDate requestDate;
+
+    // 청소 시작 희망 시간
+    private LocalTime startTime;
+
+    // 소요 시간
+    private Integer turnaround;
+
+    // 예약 금액
+    private Integer price;
+
+    // 고객 요청사항 메모
+    private String memo;
+}

--- a/common/src/main/java/com/kernel/common/reservation/dto/response/ServiceCategoryTreeDTO.java
+++ b/common/src/main/java/com/kernel/common/reservation/dto/response/ServiceCategoryTreeDTO.java
@@ -1,0 +1,20 @@
+package com.kernel.common.reservation.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ServiceCategoryTreeDTO {
+
+    private Long serviceId;         // 서비스 ID
+    private String serviceName;     // 서비스 이름
+    private Integer serviceTime;    // 서비스 제공 시간
+    private Integer depth;          // 카테고리 깊이
+    private Integer price;          // 가격
+    private String description;     // 설명
+
+    private List<ServiceCategoryTreeDTO> children;  // 자식 카테고리
+}

--- a/common/src/main/java/com/kernel/common/reservation/entity/Reservation.java
+++ b/common/src/main/java/com/kernel/common/reservation/entity/Reservation.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
@@ -36,8 +37,9 @@ public class Reservation extends BaseEntity {
     private Customer customer;
 
     // 매니저 ID
+    // 예약 요청 시에는 매니저 Null로 저장, 매니저 매칭 선택 후 저장
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "manager_id", nullable = false)
+    @JoinColumn(name = "manager_id")
     private Manager manager;
 
     // 우편번호
@@ -55,12 +57,20 @@ public class Reservation extends BaseEntity {
     @Column(length = 100, nullable = false)
     private String detailAddress;
 
+    // 위도
+    @Column(precision = 10, scale = 7, nullable = false)
+    private BigDecimal latitude;
+
+    // 경도
+    @Column(precision = 10, scale = 7, nullable = false)
+    private BigDecimal longitude;
+
     // 청소 요청 날짜
     @Column(nullable = false)
     private LocalDate requestDate;
 
     // 청소 시작 희망 시간
-    @Column(nullable = false)
+    @Column(columnDefinition = "time(0)", nullable = false)
     private LocalTime startTime;
 
     // 소요 시간
@@ -92,5 +102,11 @@ public class Reservation extends BaseEntity {
     public void cancelReservation(String cancelReason, ReservationStatus status) {
         this.cancelReason = cancelReason;
         this.status = status;
+    }
+
+    // 예약 확정
+    public void confirmReservation(Manager manager) {
+        this.manager = manager;
+        this.status = ReservationStatus.CONFIRMED;
     }
 }

--- a/common/src/main/java/com/kernel/common/reservation/entity/ServiceCategory.java
+++ b/common/src/main/java/com/kernel/common/reservation/entity/ServiceCategory.java
@@ -46,6 +46,13 @@ public class ServiceCategory extends BaseEntity {
     @JoinColumn(name = "parent_id")
     private ServiceCategory parentId;
 
+    // 가격
+    @Column
+    private Integer price;
+
+    // 설명
+    @Column(nullable = false, length = 100)
+    private String description;
 
     // 엔터티 생성시 depth를 계산 및 기본값 설정을 위한 메서드
     // Prepersist 어노테이션은 한 클래스에 하나만 사용할 수 있는 제약 조건이 있어서 하나의 메서드로 구현

--- a/common/src/main/java/com/kernel/common/reservation/enums/ReservationStatus.java
+++ b/common/src/main/java/com/kernel/common/reservation/enums/ReservationStatus.java
@@ -6,8 +6,8 @@ import lombok.Getter;
 public enum ReservationStatus {
 
     REQUESTED("예약 요청"),
-    CONFIRMED("예약 완료"),
     IN_PROGRESS("예약 진행 중"),
+    CONFIRMED("예약 완료"),
     COMPLETED("방문 완료"),
     CANCELED("예약 취소"),
     REJECTED("예약 거절"),

--- a/common/src/main/java/com/kernel/common/reservation/repository/CustomCustomerReservationRepository.java
+++ b/common/src/main/java/com/kernel/common/reservation/repository/CustomCustomerReservationRepository.java
@@ -14,4 +14,7 @@ public interface CustomCustomerReservationRepository {
 
     // 수요자 예약 상세 내역 조회
     CustomerReservationDetailRspDTO getCustomerReservationDetail(Long customerId, Long reservationId);
+
+    // 수요자 예약 조회
+    CustomerReservationRspDTO getCustomerReservations(Long customerId, Long reservationId);
 }

--- a/common/src/main/java/com/kernel/common/reservation/repository/CustomCustomerReservationRepositoryImpl.java
+++ b/common/src/main/java/com/kernel/common/reservation/repository/CustomCustomerReservationRepositoryImpl.java
@@ -167,6 +167,49 @@ public class CustomCustomerReservationRepositoryImpl implements CustomCustomerRe
     }
 
     /**
+     * 수요자 예약 조회
+     * @param customerId 수요자ID
+     * @param reservationId 페이징 정보
+     * @return 조회된 예약 내용
+     */
+    @Override
+    public CustomerReservationRspDTO getCustomerReservations(Long customerId, Long reservationId) {
+
+        // 수요자 예약 내역 조회
+        Tuple tuple = queryFactory
+                .select(
+                        reservation.reservationId,      // 예약ID
+                        manager.userName,               // 매니저 이름
+                        reservation.status,             // 예약 상태
+                        serviceCategory.serviceName,    // 서비스 카테고리 이름
+                        reservation.requestDate,        // 서비스 요청 날짜
+                        reservation.startTime,          // 서비스 시작 시간
+                        reservation.turnaround,         // 서비스 소요 시간
+                        reservation.price               // 예약 금액
+                )
+                .from (reservation)
+                .leftJoin(reservation.manager, manager)
+                .leftJoin(reservation.serviceCategory, serviceCategory)
+                .where(
+                        reservation.reservationId.eq(reservationId),
+                        reservation.customer.customerId.eq(customerId)
+                )
+                .fetchOne();
+
+        // Tuple -> DTO 로 변환
+        return CustomerReservationRspDTO.builder()
+                .reservationId(tuple.get(reservation.reservationId))
+                .managerName(tuple.get(manager.userName))
+                .reservationStatus(tuple.get(reservation.status))
+                .serviceName(tuple.get(serviceCategory.serviceName))
+                .requestDate(tuple.get(reservation.requestDate))
+                .startTime(tuple.get(reservation.startTime))
+                .turnaround(tuple.get(reservation.turnaround))
+                .price(tuple.get(reservation.price))
+                .build();
+    }
+
+    /**
      * 예약내역 검색 조건 (수요자 ID + 예약상태)
      * @param customerId 수요자 ID
      * @param status 예약 상태

--- a/common/src/main/java/com/kernel/common/reservation/repository/CustomServiceCategoryRepository.java
+++ b/common/src/main/java/com/kernel/common/reservation/repository/CustomServiceCategoryRepository.java
@@ -1,0 +1,14 @@
+package com.kernel.common.reservation.repository;
+
+import com.kernel.common.reservation.dto.response.ServiceCategoryTreeDTO;
+
+import java.util.List;
+
+public interface CustomServiceCategoryRepository {
+
+    // 서비스 카테고리 조회
+    List<ServiceCategoryTreeDTO> getServiceCategoryTree();
+
+    // 요청 서비스 카테고리 조회
+    ServiceCategoryTreeDTO getRequestServiceCategory(Long serviceId);
+}

--- a/common/src/main/java/com/kernel/common/reservation/repository/CustomServiceCategoryRepositoryImpl.java
+++ b/common/src/main/java/com/kernel/common/reservation/repository/CustomServiceCategoryRepositoryImpl.java
@@ -1,0 +1,154 @@
+package com.kernel.common.reservation.repository;
+
+import com.kernel.common.reservation.dto.response.ServiceCategoryTreeDTO;
+import com.kernel.common.reservation.entity.QServiceCategory;
+import com.kernel.common.reservation.entity.ServiceCategory;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomServiceCategoryRepositoryImpl implements CustomServiceCategoryRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final QServiceCategory serviceCategory = QServiceCategory.serviceCategory;
+
+    /**
+     * 서비스 카테고리 조회
+     * @return 서비스 카테고리 tree
+     */
+    @Override
+    public List<ServiceCategoryTreeDTO> getServiceCategoryTree() {
+
+        // 1. 모든 카테고리 조회 (isActive 여부 상관없이 전체 필요)
+        List<ServiceCategory> allCategories = queryFactory
+                .selectFrom(serviceCategory)
+                .orderBy(serviceCategory.sortOrder.asc())
+                .fetch();
+
+        // 2. ID → 엔티티 Map
+        Map<Long, ServiceCategory> entityMap = allCategories.stream()
+                .collect(Collectors.toMap(ServiceCategory::getServiceId, c -> c));
+
+        // 3. 실제로 포함할 카테고리만 필터링 (자기 자신과 조상들이 모두 isActive == true여야 포함)
+        List<ServiceCategory> validCategories = allCategories.stream()
+                .filter(this::isFullyActive)
+                .toList();
+
+        // 4. DTO Map 생성
+        Map<Long, ServiceCategoryTreeDTO> dtoMap = validCategories.stream()
+                .collect(Collectors.toMap(
+                        ServiceCategory::getServiceId,
+                        c -> ServiceCategoryTreeDTO.builder()
+                                .serviceId(c.getServiceId())
+                                .serviceName(c.getServiceName())
+                                .serviceTime(c.getServiceTime())
+                                .depth(c.getDepth())
+                                .price(c.getPrice())
+                                .description(c.getDescription())
+                                .children(new ArrayList<>())
+                                .build(),
+                        (a, b) -> a,
+                        LinkedHashMap::new
+                ));
+
+        // 5. 트리 구성
+        validCategories.forEach(c -> {
+            if (c.getParentId() != null && dtoMap.containsKey(c.getParentId().getServiceId())) {
+                ServiceCategoryTreeDTO parent = dtoMap.get(c.getParentId().getServiceId());
+                ServiceCategoryTreeDTO child = dtoMap.get(c.getServiceId());
+                parent.getChildren().add(child);
+            }
+        });
+
+        // 6. 최상위 루트만 반환
+        return validCategories.stream()
+                .filter(c -> c.getParentId() == null)
+                .map(c -> dtoMap.get(c.getServiceId()))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 요청 서비스 카테고리 조회
+     * @param serviceId 요청 서비스 카테고리ID
+     * @return 서비스 카테고리 tree
+     */
+    @Override
+    public ServiceCategoryTreeDTO getRequestServiceCategory(Long serviceId) {
+
+        // 1. 요청 카테고리 + 하위 카테고리 조회
+        List<ServiceCategory> filteredCategories = queryFactory
+                .selectFrom(serviceCategory)
+                .where(
+                        serviceCategory.isActive.isTrue(),
+                        serviceCategory.price.ne(0),
+                        serviceCategory.serviceId.eq(serviceId)
+                                .or(serviceCategory.parentId.serviceId.eq(serviceId) )
+                )
+                .orderBy(serviceCategory.sortOrder.asc())
+                .fetch();
+
+        if (filteredCategories == null || filteredCategories.isEmpty()) {
+            return null;
+        }
+
+        // 2. Entity → DTO 변환
+        Map<Long, ServiceCategoryTreeDTO> dtoMap = new LinkedHashMap<>();
+        Map<Long, Long> parentMap = new HashMap<>();
+
+        for (ServiceCategory category : filteredCategories) {
+            if (category == null || category.getServiceId() == null) continue;
+
+            ServiceCategoryTreeDTO dto = ServiceCategoryTreeDTO.builder()
+                    .serviceId(category.getServiceId())
+                    .serviceName(category.getServiceName())
+                    .serviceTime(category.getServiceTime())
+                    .depth(category.getDepth())
+                    .price(category.getPrice())
+                    .description(category.getDescription())
+                    .children(new ArrayList<>()) // 자식 목록 초기화
+                    .build();
+
+            dtoMap.put(category.getServiceId(), dto);
+            parentMap.put(
+                    category.getServiceId(),
+                    category.getParentId() != null ? category.getParentId().getServiceId() : null
+            ); // parent 연결용
+        }
+
+        // 3. 부모-자식 연결
+        ServiceCategoryTreeDTO root = null;
+
+        for (Map.Entry<Long, ServiceCategoryTreeDTO> entry : dtoMap.entrySet()) {
+            Long serviceCategoryId = entry.getKey();
+            ServiceCategoryTreeDTO dto = entry.getValue();
+            Long parentId = parentMap.get(serviceCategoryId);
+
+            if (parentId != null && dtoMap.containsKey(parentId)) {
+                dtoMap.get(parentId).getChildren().add(dto);
+            } else {
+                root = dto; // 최상위 루트 (요청한 ID)
+            }
+        }
+
+        return root;
+    }
+
+    /**
+     * 부모 카테고리 isActive = False 확인
+     * @return 활성 여부
+     */
+    private boolean isFullyActive(ServiceCategory category) {
+        while (category != null) {
+            if (category.getIsActive() == null || !category.getIsActive()) {
+                return false;
+            }
+            category = category.getParentId();
+        }
+        return true;
+    }
+}

--- a/common/src/main/java/com/kernel/common/reservation/repository/ReservationServiceCategoryRepository.java
+++ b/common/src/main/java/com/kernel/common/reservation/repository/ReservationServiceCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.kernel.common.reservation.repository;
+
+import com.kernel.common.reservation.entity.ServiceCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReservationServiceCategoryRepository extends JpaRepository<ServiceCategory, Long>, CustomServiceCategoryRepository {
+}

--- a/common/src/main/java/com/kernel/common/reservation/service/CustomerReservationService.java
+++ b/common/src/main/java/com/kernel/common/reservation/service/CustomerReservationService.java
@@ -2,13 +2,22 @@ package com.kernel.common.reservation.service;
 
 
 import com.kernel.common.reservation.dto.request.CustomerReservationCancelReqDTO;
+import com.kernel.common.reservation.dto.request.CustomerReservationReqDTO;
+import com.kernel.common.reservation.dto.request.ReservationConfirmReqDTO;
 import com.kernel.common.reservation.dto.response.CustomerReservationDetailRspDTO;
 import com.kernel.common.reservation.dto.response.CustomerReservationRspDTO;
+import com.kernel.common.reservation.dto.response.ReservationRspDTO;
 import com.kernel.common.reservation.enums.ReservationStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CustomerReservationService {
+
+    // 수요자 예약 요청
+    ReservationRspDTO requestCustomerReservation(Long customerId, CustomerReservationReqDTO reservationReqDTO);
+
+    // 예약 확정
+    CustomerReservationRspDTO confirmCustomerReservation(Long customerId, Long reservationId, ReservationConfirmReqDTO confirmReqDTO);
 
     // 수요자 예역 내역 검색 및 조회
     Page<CustomerReservationRspDTO> getCustomerReservations(Long customerId, ReservationStatus status, Pageable pageable);
@@ -18,4 +27,5 @@ public interface CustomerReservationService {
 
     // 수요자 예약 취소
     void cancelReservationByCustomer(Long customerId, CustomerReservationCancelReqDTO cancelReqDTO);
+
 }

--- a/common/src/main/java/com/kernel/common/reservation/service/ServiceCategoryService.java
+++ b/common/src/main/java/com/kernel/common/reservation/service/ServiceCategoryService.java
@@ -1,0 +1,14 @@
+package com.kernel.common.reservation.service;
+
+import com.kernel.common.reservation.dto.response.ServiceCategoryTreeDTO;
+
+import java.util.List;
+
+public interface ServiceCategoryService {
+
+    // 서비스 카테고리 조회
+    List<ServiceCategoryTreeDTO> getServiceCategoryTree();
+
+    // 요청 서비스 카테고리 조회
+    ServiceCategoryTreeDTO getRequestServiceCategory(Long serviceId);
+}

--- a/common/src/main/java/com/kernel/common/reservation/service/ServiceCategoryServiceImpl.java
+++ b/common/src/main/java/com/kernel/common/reservation/service/ServiceCategoryServiceImpl.java
@@ -1,0 +1,39 @@
+package com.kernel.common.reservation.service;
+
+import com.kernel.common.reservation.dto.response.ServiceCategoryTreeDTO;
+import com.kernel.common.reservation.repository.ReservationServiceCategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ServiceCategoryServiceImpl implements ServiceCategoryService {
+
+    private final ReservationServiceCategoryRepository serviceCategoryRepository;
+
+    /**
+     * 서비스 카테고리 조회
+     * @return 서비스 카테고리 tree
+     */
+    @Override
+    @Transactional
+    public List<ServiceCategoryTreeDTO> getServiceCategoryTree() {
+
+        return serviceCategoryRepository.getServiceCategoryTree();
+    }
+
+    /**
+     * 요청 서비스 카테고리 조회
+     * @param serviceId 요청 서비스 카테고리ID
+     * @return 서비스 카테고리 tree
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public ServiceCategoryTreeDTO getRequestServiceCategory(Long serviceId) {
+
+        return serviceCategoryRepository.getRequestServiceCategory(serviceId);
+    }
+}


### PR DESCRIPTION
## 기능 구현
1. 예약 시 노출될 서비스 카테고리 조회
2. 수요자 예약 요청
    - 매니저 매칭 리스트 응답 및 매칭 리스트 매니저 상태 변경(MATCHING)
    - 요청한 서비스 카테고리의 자식 카테고리 응답
    - 요청한 예약 정보 응답
 3. 수요자 예약 확정
    - 선택한 매니저 예약 정보 저장 및 예약 상태 변경(CONFIRM)
    - 매칭리스트의 모든 매니저 상태변경(ACTIVE)
3. 관련 엔티티, Enum 수정
    -  UserSatus Enum : MATCHING 추가
    -  ServiceCategory 엔티티 : 가격, 설명 컬럼 추가
    - Reservation 엔티티 : mangerID Nullable 로 수정
 4. 매칭 알고리즘 기본 구조 구현
    - ACTIVE 매니저 조회
    - 조회 후 매니저 상태 MATCHING 으로 전환
    
  ## 관련 이슈
https://github.com/Kernel360/KBE5_HALO_BE/issues/107