### PR TITLE
[관리자] 수요자 및 매니저 문의사항 검색 오류 수정

### DIFF
--- a/common/src/main/java/com/kernel/common/admin/dto/response/AdminInquirySummaryRspDTO.java
+++ b/common/src/main/java/com/kernel/common/admin/dto/response/AdminInquirySummaryRspDTO.java
@@ -1,6 +1,5 @@
 package com.kernel.common.admin.dto.response;
 
-import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 

--- a/common/src/main/java/com/kernel/common/admin/service/AdminManagerInquiryServiceImpl.java
+++ b/common/src/main/java/com/kernel/common/admin/service/AdminManagerInquiryServiceImpl.java
@@ -57,7 +57,7 @@ public class AdminManagerInquiryServiceImpl implements AdminManagerInquiryServic
         List<Manager> authors = managerRepository.findByUserNameContaining(request.getAuthorName().trim());
 
         if (authors.isEmpty()) {
-            throw new NoSuchElementException("해당 이름의 매니저를 찾을 수 없습니다.");
+            return new PageImpl<>(List.of(), pageable, 0);
         }
 
         // request의 작성자 이름인 모든 id를 추출

--- a/common/src/main/java/com/kernel/common/customer/repository/CustomCustomerInquiryRepositoryImpl.java
+++ b/common/src/main/java/com/kernel/common/customer/repository/CustomCustomerInquiryRepositoryImpl.java
@@ -2,10 +2,7 @@ package com.kernel.common.customer.repository;
 
 import com.kernel.common.admin.dto.request.AdminInquirySearchReqDTO;
 import com.kernel.common.admin.repository.AdminRepository;
-import com.kernel.common.customer.entity.CustomerInquiry;
-import  com.kernel.common.customer.entity.QCustomerInquiry;
-import com.kernel.common.customer.entity.QCustomerReply;
-import com.kernel.common.customer.entity.QInquiryCategory;
+import com.kernel.common.customer.entity.*;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -107,13 +104,15 @@ public class CustomCustomerInquiryRepositoryImpl implements CustomCustomerInquir
         BooleanExpression condition = inquiry.isDeleted.eq(false);
 
         if (query.getAuthorName() != null && !query.getAuthorName().isBlank()) {
-            Long authorId = customerRepository.findByUserName(query.getAuthorName())
-                    .orElseThrow(() -> new IllegalArgumentException("작성자를 찾을 수 없습니다: " + query.getAuthorName()));
-            condition = condition.and(inquiry.authorId.eq(authorId));
+            Optional<Customer> customer = customerRepository.findByUserName(query.getAuthorName());
+            if (customer.isEmpty()) {
+                return new PageImpl<>(List.of(), pageable, 0);
+            }
+            condition = condition.and(inquiry.authorId.eq(customer.get().getCustomerId()));
         }
 
-        if (query.getAuthorName() != null && !query.getAuthorName().isBlank()) {
-            condition = condition.and(inquiry.title.containsIgnoreCase(query.getAuthorName()));
+        if (query.getTitle() != null && !query.getTitle().isBlank()) {
+            condition = condition.and(inquiry.title.containsIgnoreCase(query.getTitle()));
         }
 
         if (query.getCategory() != null) {

--- a/common/src/main/java/com/kernel/common/customer/repository/CustomerRepository.java
+++ b/common/src/main/java/com/kernel/common/customer/repository/CustomerRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface CustomerRepository extends JpaRepository<Customer, Long> {
-    Optional<Long> findByUserName(String username);
+    Optional<Customer> findByUserName(String username);
 }


### PR DESCRIPTION
### 작업내용
- 프론트에서 쿼리를 보냈을 때 정상적인 쿼리를 진행하지 못한 오류 수정
  - 수요자 오류
    - 수요자 이름으로 수요자 id 검색 오류 수정
    - 수요자 이름으로 수요자를 찾을 수 없을 때 예외 출력 대신 빈 결과를 반환하도록 수정
  - 매니저 오류
    - 쿼리에 반드시 매니저 id를 포함해야하는 문제 수정
    - 매니저 이름으로 매니저를 찾을 수 없을 때 예외 출력 대신 빈 결과를 반환하도록 수정

### 관련 이슈
- Close #47