### PR TITLE
fix: JPQL delete 쿼리로 Refresh 토큰 삭제 로직 수정

### DIFF
--- a/api/src/main/java/com/kernel/app/controller/ReissueController.java
+++ b/api/src/main/java/com/kernel/app/controller/ReissueController.java
@@ -8,6 +8,7 @@ import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -32,6 +33,7 @@ public class ReissueController {
     private final JwtProperties jwtProperties;
 
     @PostMapping("/reissue")
+    @Transactional
     public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {
 
         String refreshToken = extractRefreshTokenFromCookies(request);

--- a/api/src/main/java/com/kernel/app/repository/RefreshRepository.java
+++ b/api/src/main/java/com/kernel/app/repository/RefreshRepository.java
@@ -3,11 +3,16 @@ package com.kernel.app.repository;
 import com.kernel.app.entity.Refresh;
 import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RefreshRepository extends JpaRepository<Refresh, Long> {
 
     Boolean existsByRefreshToken(String refreshToken);
 
     @Transactional
-    void deleteByRefreshToken(String refreshToken);
+    @Modifying
+    @Query("DELETE FROM refresh r WHERE r.refreshToken = :refreshToken")
+    void deleteByRefreshToken(@Param("refreshToken") String refreshToken);
 }


### PR DESCRIPTION
- 기존 deleteByRefreshToken에서 발생하던 ConcurrentModificationException 해결
- JPA select-before-delete 방식 대신 JPQL을 사용해 즉시 삭제되도록 개선