### PR TITLE
[관리자] 매니저 목록 조회 방식 변경 및 관리자 계정 로그인 사용자 표시 변경

### DIFF
--- a/api/src/main/java/com/kernel/app/jwt/CustomLoginFilter.java
+++ b/api/src/main/java/com/kernel/app/jwt/CustomLoginFilter.java
@@ -105,7 +105,7 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
                 AdminUserDetails userDetails = (AdminUserDetails) authentication.getPrincipal();
                 phone = userDetails.getUsername();
                 userId = userDetails.getUserId();
-                name = userDetails.getUsername();
+                name = userDetails.getName();
                 status = userDetails.getStatus();
             }
             default -> throw new IllegalStateException("Unsupported user type: " + userType);

--- a/common/src/main/java/com/kernel/common/admin/dto/request/AdminManagerSearchReqDTO.java
+++ b/common/src/main/java/com/kernel/common/admin/dto/request/AdminManagerSearchReqDTO.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 import lombok.ToString;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 @Getter
 @Setter
@@ -26,6 +27,9 @@ public class AdminManagerSearchReqDTO {
 
     // 매니저 상태
     private String status;
+
+    // 제외시킬 매니저 상태
+    private List<String> excludeStatus;
 
     // 매니저 평점 범위
     @Min(value = 0, message = "최소 평점은 0 이상이어야 합니다.")

--- a/common/src/main/java/com/kernel/common/admin/service/AdminCustomerServiceImpl.java
+++ b/common/src/main/java/com/kernel/common/admin/service/AdminCustomerServiceImpl.java
@@ -17,6 +17,12 @@ public class AdminCustomerServiceImpl implements AdminCustomerService {
 
     private final AdminCustomerRepository repository;
 
+    /**
+     * 수요자 목록 조회
+     *
+     * @param keyword 검색어 (전화번호)
+     * @return 수요자 목록
+     */
     public List<AdminCustomerResDto> getAllCustomers(String keyword) {
         List<Customer> customer;
 
@@ -31,6 +37,12 @@ public class AdminCustomerServiceImpl implements AdminCustomerService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * 수요자 상세 조회
+     *
+     * @param customerId 수요자 ID
+     * @return 수요자 상세 정보
+     */
     public AdminCustomerResDto getCustomerDetail(Long customerId) {
         Customer customer = repository.findById(customerId)
                 .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 수요자입니다."));

--- a/common/src/main/java/com/kernel/common/global/AuthenticatedUser.java
+++ b/common/src/main/java/com/kernel/common/global/AuthenticatedUser.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 public interface AuthenticatedUser {
     String getUsername();
     Long getUserId();
+
     UserStatus getStatus();
     Collection<? extends GrantedAuthority> getAuthorities();
 }

--- a/common/src/main/java/com/kernel/common/global/security/AdminUserDetails.java
+++ b/common/src/main/java/com/kernel/common/global/security/AdminUserDetails.java
@@ -46,6 +46,8 @@ public class AdminUserDetails implements UserDetails, AuthenticatedUser {
         return admin.getAdminId();
     }
 
+    public String getName() { return admin.getUserName(); }
+
     @Override
     public boolean isAccountNonExpired() {
         return true;

--- a/common/src/main/java/com/kernel/common/manager/repository/CustomManagerRepositoryImpl.java
+++ b/common/src/main/java/com/kernel/common/manager/repository/CustomManagerRepositoryImpl.java
@@ -34,6 +34,7 @@ public class CustomManagerRepositoryImpl implements CustomManagerRepository {
                         phoneEq(request.getPhone()),
                         emailEq(request.getEmail()),
                         statusEq(request.getStatus()),
+                        statusNotIn(request.getExcludeStatus()),
                         averageRatingGoe(request.getMinRating()),
                         averageRatingLoe(request.getMaxRating())
                 )
@@ -47,6 +48,7 @@ public class CustomManagerRepositoryImpl implements CustomManagerRepository {
                         phoneEq(request.getPhone()),
                         emailEq(request.getEmail()),
                         statusEq(request.getStatus()),
+                        statusNotIn(request.getExcludeStatus()),
                         averageRatingGoe(request.getMinRating()),
                         averageRatingLoe(request.getMaxRating())
                 )
@@ -73,6 +75,15 @@ public class CustomManagerRepositoryImpl implements CustomManagerRepository {
         }
         UserStatus userStatus = UserStatus.valueOf(status);
         return status != null ? QManager.manager.status.eq(userStatus) : null;
+    }
+
+    private BooleanExpression statusNotIn(List<String> excludeStatus) {
+        if (excludeStatus == null || excludeStatus.isEmpty()) {
+            return null;
+        }
+        return QManager.manager.status.notIn(excludeStatus.stream()
+                .map(UserStatus::valueOf)
+                .toList());
     }
 
     private BooleanExpression averageRatingGoe(BigDecimal minRating) {


### PR DESCRIPTION
### 작업내용
- 매니저 목록 조회 방식 변경
  - 프론트에서 매니저 목록 조회시 제외할 상태를 보내면 해당 상태를 제외한 결과를 쿼리하도록 수정

- 관리자 계정 로그인 사용자 표시 변경
  - 프론트에서 관리자 계정에 로그인하면 관리자 이름 대신 연락처가 표시되는 문제
  - JwtFilter에서 관리자의 userName 대신 name을 담아 응답을 보내는 방식을 수정