### PR TITLE
[관리자] 매니저의 근무 가능 시간 조회 오류 수정

### DIFF
--- a/common/src/main/java/com/kernel/common/admin/dto/mapper/AdminManagerMapper.java
+++ b/common/src/main/java/com/kernel/common/admin/dto/mapper/AdminManagerMapper.java
@@ -2,6 +2,8 @@ package com.kernel.common.admin.dto.mapper;
 
 import com.kernel.common.admin.dto.response.AdminManagerSummaryRspDTO;
 import com.kernel.common.admin.dto.response.AdminManagerRspDTO;
+import com.kernel.common.manager.dto.response.AvailableTimeRspDTO;
+import com.kernel.common.manager.entity.AvailableTime;
 import com.kernel.common.manager.entity.Manager;
 
 import lombok.RequiredArgsConstructor;
@@ -13,6 +15,14 @@ import java.util.stream.Collectors;
 @Component
 @RequiredArgsConstructor
 public class AdminManagerMapper {
+
+    // AvailableTime → AvailableTimeRspDTO
+    private AvailableTimeRspDTO toAvailableTimeRspDTO(AvailableTime time) {
+        return AvailableTimeRspDTO.builder()
+                .dayOfWeek(time.getDayOfWeek()) // 가능 요일
+                .time(time.getTime())           // 가능 시간
+                .build();
+    }
 
     // Manager Entity -> AdminManagerRspDTO
     public AdminManagerRspDTO toAdminManagerRspDTO(Manager manager) {
@@ -32,7 +42,9 @@ public class AdminManagerMapper {
                 .bio(manager.getBio())
                 .profileImageId(manager.getProfileImageId())
                 .fileId(manager.getFileId())  // 첨부파일 ID
-                .availableTimes(manager.getAvailableTimes())
+                .availableTimes(manager.getAvailableTimes().stream()
+                        .map(this::toAvailableTimeRspDTO)
+                        .toList())
                 //.availableArea(manager.getAvailableArea())    // availableArea는 Manager 패키지에서 정의된 Entity라고 가정
                 .createdAt(manager.getCreatedAt())
                 .updatedAt(manager.getUpdatedAt())

--- a/common/src/main/java/com/kernel/common/admin/dto/response/AdminManagerRspDTO.java
+++ b/common/src/main/java/com/kernel/common/admin/dto/response/AdminManagerRspDTO.java
@@ -3,6 +3,7 @@ package com.kernel.common.admin.dto.response;
 import com.kernel.common.global.enums.Gender;
 import com.kernel.common.global.enums.UserStatus;
 
+import com.kernel.common.manager.dto.response.AvailableTimeRspDTO;
 import com.kernel.common.manager.entity.AvailableTime;
 import lombok.*;
 
@@ -33,7 +34,7 @@ public class AdminManagerRspDTO {
     private Long profileImageId;
     private Long fileId;  // 첨부파일 ID
     ///private List<AvailableAreaResponseDTO> availableArea;   // AvailableArea는 Manager 패키지에서 정의된 DTO라고 가정
-    private List<AvailableTime> availableTimes;   // AvailableTime는 Manager 패키지에서 정의된 DTO라고 가정
+    private List<AvailableTimeRspDTO> availableTimes;   // AvailableTime는 Manager 패키지에서 정의된 DTO라고 가정
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private LocalDateTime contractAt;


### PR DESCRIPTION
### 작업내용
- 매니저 상세 조회 오류 수정
  - 기존 매니저의 근무 가능 시간 객체를 자체를 응답시 순환 참조 문제 발생
  - 요일과 시간 정보만 추출해서 반환

### 관련 이슈
- Close #42 