### PR TITLE
[관리자] 관리자의 수요자, 매니저 문의사항 검색 로직 개선

### DIFF
--- a/common/src/main/java/com/kernel/common/admin/dto/request/AdminInquirySearchReqDTO.java
+++ b/common/src/main/java/com/kernel/common/admin/dto/request/AdminInquirySearchReqDTO.java
@@ -1,7 +1,9 @@
 package com.kernel.common.admin.dto.request;
 
+import com.kernel.common.global.enums.ReplyStatus;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 
@@ -25,8 +27,23 @@ public class AdminInquirySearchReqDTO {
     private String replyStatus;
 
     // 등록일 범위 시작일
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDateTime fromCreatedAt;
 
     // 등록일 범위 종료일
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDateTime toCreatedAt;
+
+    public ReplyStatus replyStatusFilter() {
+        if (replyStatus == null || replyStatus.isEmpty()) {
+            return null;
+        }
+
+        try {
+            return ReplyStatus.valueOf(replyStatus.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            // 유효하지 않은 상태 값인 경우 null 반환
+            return null;
+        }
+    }
 }

--- a/common/src/main/java/com/kernel/common/admin/service/AdminManagerInquiryServiceImpl.java
+++ b/common/src/main/java/com/kernel/common/admin/service/AdminManagerInquiryServiceImpl.java
@@ -56,7 +56,7 @@ public class AdminManagerInquiryServiceImpl implements AdminManagerInquiryServic
                     ? managerReplyRepository.findById(inquiry.getManagerReply().getAnswerId()).orElse(null)
                     : null; // 답변이 없을 수도 있으므로 null 처리
             Manager author = managerRepository.findById(inquiry.getAuthorId())
-                    .orElseThrow(() -> new NoSuchElementException("작성자를 찾을 수 없습니다."));
+                    .orElse(null);
             return adminInquiryMapper.toSummaryRspDTO(inquiry);
         });
     }

--- a/common/src/main/java/com/kernel/common/manager/repository/CustomManagerInquiryRepositoryImpl.java
+++ b/common/src/main/java/com/kernel/common/manager/repository/CustomManagerInquiryRepositoryImpl.java
@@ -74,6 +74,7 @@ public class CustomManagerInquiryRepositoryImpl implements CustomManagerInquiryR
 
 
     public Page<ManagerInquiry> searchManagerInquiryWithReply(AdminInquirySearchReqDTO request, Pageable pageable) {
+
         QManagerInquiry managerInquiry = QManagerInquiry.managerInquiry;
         QManagerReply managerReply = QManagerReply.managerReply;
 
@@ -88,8 +89,8 @@ public class CustomManagerInquiryRepositoryImpl implements CustomManagerInquiryR
                     titleContains(request.getTitle()),
                     contentContains(request.getContent()),
                     createdAtGoe(request.getFromCreatedAt()),
-                    createdAtLoe(request.getToCreatedAt())
-                    //replyStatusCond(request.getReplyStatus(), managerInquiry)
+                    createdAtLoe(request.getToCreatedAt()),
+                    replyStatusCond(request.replyStatusFilter(), managerInquiry)
                 )
                 .fetchOne()
         ).orElse(0L);
@@ -103,8 +104,8 @@ public class CustomManagerInquiryRepositoryImpl implements CustomManagerInquiryR
                 titleContains(request.getTitle()),
                 contentContains(request.getContent()),
                 createdAtGoe(request.getFromCreatedAt()),
-                createdAtLoe(request.getToCreatedAt())
-                //replyStatusCond(request.getReplyStatus(), managerInquiry)
+                createdAtLoe(request.getToCreatedAt()),
+                replyStatusCond(request.replyStatusFilter(), managerInquiry)
             )
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
@@ -113,7 +114,6 @@ public class CustomManagerInquiryRepositoryImpl implements CustomManagerInquiryR
 
         return new PageImpl<>(results, pageable, total);
     }
-
 
     // 작성자 ID 일치
     private BooleanExpression authorEq(Long authorId) {


### PR DESCRIPTION
### 작업내용
- 수요자 문의사항 검색 로직 리펙토링
  - 검색 조건을 별도의 BooleanExpression 타입을 반환하는 함수를 호출해서 where에 삽입
- 매니저 문의사항 검색 로직에서 replyStatus 추가

### 관련 이슈
- Close #47 #156 
