### PR TITLE
[Refactor] Manager 기능 리펙토링

### DIFF
--- a/.github/workflows/notify-discord-on-pr.yml
+++ b/.github/workflows/notify-discord-on-pr.yml
@@ -18,11 +18,11 @@ jobs:
         with:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
           content: |
-            ## 🛠️ Pull Request 알림
+            # 🛠️ Pull Request 알림
             **제목**: ${{ github.event.pull_request.title }}
             **작성자**: `${{ github.actor }}`
             **URL**: <${{ github.event.pull_request.html_url }}>
-            ## 📝 리뷰 요청
+            # 📝 리뷰 요청
             `${{ github.event.pull_request.body || '리뷰 부탁드립니다!' }}`
 
       - name: 커밋 메시지 가져오기 (synchronize)

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -18,6 +18,11 @@ repositories {
 }
 
 dependencies {
+    // Module dependencies
+    implementation project(':global')
+    implementation project(':reservation')
+
+    // Spring Boot Starter
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     // Spring Security

--- a/evaluation/build.gradle
+++ b/evaluation/build.gradle
@@ -18,6 +18,10 @@ repositories {
 }
 
 dependencies {
+    // Module dependencies
+    implementation project(':global')
+    implementation project(':reservation')
+
     // Spring Boot dependencies
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/evaluation/src/main/java/com/kernel/evaluation/domain/entity/Feedback.java
+++ b/evaluation/src/main/java/com/kernel/evaluation/domain/entity/Feedback.java
@@ -1,7 +1,7 @@
 package com.kernel.evaluation.domain.entity;
 
 
-import com.kernel.evaluation.domain.enumerate.FeedbackType;
+import com.kernel.evaluation.domain.enums.FeedbackType;
 
 public class Feedback {
 

--- a/evaluation/src/main/java/com/kernel/evaluation/domain/enums/AuthorType.java
+++ b/evaluation/src/main/java/com/kernel/evaluation/domain/enums/AuthorType.java
@@ -1,0 +1,19 @@
+package com.kernel.evaluation.domain.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum AuthorType {
+    CUSTOMER("수요자"),
+    MANAGER("매니저");
+
+    private final String label;
+
+    AuthorType(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+}

--- a/evaluation/src/main/java/com/kernel/evaluation/domain/enums/FeedbackType.java
+++ b/evaluation/src/main/java/com/kernel/evaluation/domain/enums/FeedbackType.java
@@ -1,4 +1,4 @@
-package com.kernel.evaluation.domain.enumerate;
+package com.kernel.evaluation.domain.enums;
 
 public enum FeedbackType {
 

--- a/global/src/main/java/com/kernel/global/common/constant/SecurityUrlConstants.java
+++ b/global/src/main/java/com/kernel/global/common/constant/SecurityUrlConstants.java
@@ -11,11 +11,11 @@ public class SecurityUrlConstants  {
 
     // 인증 불필요 (모든 사용자 접근 가능)
     public static final String[] PUBLIC_URLS = {
-            "/api/customers/auth/login",
+            //"/api/customers/auth/login",
             "/api/customers/auth/signup",
-            "/api/managers/auth/login",
+            //"/api/managers/auth/login",
             "/api/managers/auth/signup",
-            "/api/admin/auth/login",
+            //"/api/admin/auth/login",
             "/api/common/recovery-id",
             "/api/common/recovery-pwd"
     };

--- a/global/src/main/java/com/kernel/global/jwt/JwtFilter.java
+++ b/global/src/main/java/com/kernel/global/jwt/JwtFilter.java
@@ -1,6 +1,7 @@
 package com.kernel.global.jwt;
 
 import com.kernel.global.common.constant.SecurityUrlConstants;
+import com.kernel.global.common.enums.UserRole;
 import com.kernel.global.common.enums.UserStatus;
 import com.kernel.global.domain.entity.User;
 import com.kernel.global.security.CustomUserDetails;
@@ -75,9 +76,10 @@ public class JwtFilter extends OncePerRequestFilter {
         String phone = jwtTokenProvider.getUsername(accessToken);
         Long userId = jwtTokenProvider.getUserId(accessToken);
         String status = jwtTokenProvider.getStatus(accessToken);
+        String role = jwtTokenProvider.getRole(accessToken);
 
         // UserDetails 객체 생성
-        UserDetails userDetails = createUserDetailsFromToken(phone, userId, status);
+        UserDetails userDetails = createUserDetailsFromToken(phone, userId, status, role);
 
         // 인증 객체 생성
         Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
@@ -90,12 +92,15 @@ public class JwtFilter extends OncePerRequestFilter {
     }
 
     // 로그인 유저 UserDetails 객체 생성
-    private UserDetails createUserDetailsFromToken(String phone, Long userId, String status) {
+    private UserDetails createUserDetailsFromToken(String phone, Long userId, String status, String role) {
+
+        String formattedRole = role.replace("ROLE_", "");
 
         User user = User.builder()
                 .userId(userId)
                 .phone(phone)
                 .status(UserStatus.valueOf(status))
+                .role(UserRole.valueOf(formattedRole))
                 .build();
 
         return new CustomUserDetails(user);

--- a/global/src/main/java/com/kernel/global/repository/FileRepository.java
+++ b/global/src/main/java/com/kernel/global/repository/FileRepository.java
@@ -3,5 +3,8 @@ package com.kernel.global.repository;
 import com.kernel.global.domain.entity.File;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FileRepository extends JpaRepository<File, Long> {
+    Optional<File> findByFileId(Long fileId);
 }

--- a/global/src/main/java/com/kernel/global/security/CustomUserDetailsService.java
+++ b/global/src/main/java/com/kernel/global/security/CustomUserDetailsService.java
@@ -13,14 +13,12 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 
-    private UserRepository userRepository;
+    private final UserRepository userRepository;
 
     @Override
     public UserDetails loadUserByUsername(String phone) throws UsernameNotFoundException {
-
         User user = userRepository.findByPhone(phone)
                 .orElseThrow(() -> new UsernameNotFoundException("회원이 존재하지 않습니다."));
-
         return new CustomUserDetails(user);
 
     }

--- a/member/build.gradle
+++ b/member/build.gradle
@@ -18,8 +18,10 @@ repositories {
 }
 
 dependencies {
-
+    // Module dependencies
     implementation project(':global')
+    implementation project(':reservation')
+    implementation project(':evaluation')
 
     // Spring Boot dependencies
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/member/src/main/java/com/kernel/member/common/enums/ContractStatus.java
+++ b/member/src/main/java/com/kernel/member/common/enums/ContractStatus.java
@@ -3,6 +3,7 @@ package com.kernel.member.common.enums;
 public enum ContractStatus {
 
     PENDING("승인대기"),                // 매니저 승인 대기
+    APPROVED("승인완료"),              // 매니저 승인 완료
     REJECTED("승인거절"),               // 매니저 승인 거절
     TERMINATION_PENDING("계약해지대기"), // 매니저 계약 해지 대기
     TERMINATED("계약해지");             // 매니저 계약 해지

--- a/member/src/main/java/com/kernel/member/common/enums/DayOfWeek.java
+++ b/member/src/main/java/com/kernel/member/common/enums/DayOfWeek.java
@@ -1,0 +1,34 @@
+package com.kernel.member.common.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum DayOfWeek {
+    MONDAY("월", "월요일", 1),
+    TUESDAY("화", "화요일", 2),
+    WEDNESDAY("수", "수요일", 3),
+    THURSDAY("목", "목요일", 4),
+    FRIDAY("금", "금요일", 5),
+    SATURDAY("토", "토요일", 6),
+    SUNDAY("일", "일요일", 0); // 일요일만 0으로 설정
+
+    private final String label;
+    private final String fullLabel;
+    private final int value; // ← 추가
+
+    DayOfWeek(String label, String fullLabel, int value) {
+        this.label = label;
+        this.fullLabel = fullLabel;
+        this.value = value;
+    }
+
+    public static DayOfWeek fromJavaDayOfWeek(java.time.DayOfWeek javaDayOfWeek) {
+        int val = javaDayOfWeek.getValue() % 7; // 일요일이면 7 → 0
+        for (DayOfWeek day : DayOfWeek.values()) {
+            if (day.getValue() == val) {
+                return day;
+            }
+        }
+        throw new IllegalArgumentException("Invalid day value: " + val);
+    }
+}

--- a/member/src/main/java/com/kernel/member/controller/ManagerController.java
+++ b/member/src/main/java/com/kernel/member/controller/ManagerController.java
@@ -1,0 +1,83 @@
+package com.kernel.member.controller;
+
+import com.kernel.global.security.CustomUserDetails;
+import com.kernel.global.service.dto.response.ApiResponse;
+import com.kernel.member.service.ManagerService;
+import com.kernel.member.service.ManagerTerminationService;
+import com.kernel.member.service.request.ManagerSignupReqDTO;
+import com.kernel.member.service.request.ManagerTerminationReqDTO;
+import com.kernel.member.service.request.ManagerUpdateReqDTO;
+import com.kernel.member.service.response.ManagerDetailRspDTO;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/managers/auth")
+@RequiredArgsConstructor
+public class ManagerController {
+
+    private final ManagerService managerService;
+    private final ManagerTerminationService managerTerminationService;
+
+    /**
+     * 매니저 회원가입
+     * @param signupReqDTO 매니저 회원가입 요청 DTO
+     * @return 회원가입 성공 응답
+     */
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<Void>> signup(
+            @RequestBody @Valid ManagerSignupReqDTO signupReqDTO
+    ) {
+        // 매니저 회원가입 로직
+        managerService.signup(signupReqDTO);
+        return ResponseEntity.ok(new ApiResponse<>(true, "매니저 회원가입 성공", null));
+    }
+
+    /**
+     * 매니저 정보 조회
+     * @param manager 인증된 매니저 정보
+     * @return 매니저 정보를 담은 응답
+     */
+    @GetMapping("/my")
+    public ResponseEntity<ApiResponse<ManagerDetailRspDTO>> getManager(
+            @AuthenticationPrincipal CustomUserDetails manager
+    ) {
+        ManagerDetailRspDTO infoRspDTO = managerService.getManager(manager.getUserId());
+        return ResponseEntity.ok(new ApiResponse<>(true, "매니저 정보 조회 성공", infoRspDTO));
+    }
+
+    /**
+     * 매니저 정보 수정
+     * @param manager 인증된 매니저 정보
+     * @param updateReqDTO 매니저 정보 수정 요청 DTO
+     * @return 수정된 매니저 정보를 담은 응답
+     */
+    @PatchMapping("/my")
+    public ResponseEntity<ApiResponse<ManagerDetailRspDTO>> updateManager(
+            @AuthenticationPrincipal CustomUserDetails manager,
+            @RequestBody @Valid ManagerUpdateReqDTO updateReqDTO
+    ) {
+        ManagerDetailRspDTO updateRspDTO = managerService.updateManager(manager.getUserId(), updateReqDTO);
+        return ResponseEntity.ok(new ApiResponse<>(true, "매니저 정보 수정 성공", updateRspDTO));
+    }
+
+    /**
+     * 매니저 계약 해지 요청
+     * @param manager 인증된 매니저 정보
+     * @param request 계약 해지 요청 DTO
+     * @return 계약 해지 요청 성공 응답
+     */
+    @PostMapping("/termination")
+    public ResponseEntity<ApiResponse<Void>> requestTermination(
+            @AuthenticationPrincipal CustomUserDetails manager,
+            @RequestBody @Valid ManagerTerminationReqDTO request
+    ) {
+        // 매니저 계약 해지 요청 처리
+        managerTerminationService.requestTermination(manager.getUserId(), request);
+        return ResponseEntity.ok(new ApiResponse<>(true, "매니저 계약 해지 요청 성공", null));
+    }
+
+}

--- a/member/src/main/java/com/kernel/member/domain/entity/AvailableTime.java
+++ b/member/src/main/java/com/kernel/member/domain/entity/AvailableTime.java
@@ -1,17 +1,40 @@
 package com.kernel.member.domain.entity;
 
+import com.kernel.global.domain.entity.User;
+import com.kernel.member.common.enums.DayOfWeek;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
 import java.time.LocalTime;
 
+@Entity
+@Table(name = "available_time")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@SuperBuilder
 public class AvailableTime {
+
     // 업무 가능 시간 ID
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column
     private Long availableTimeId;
 
     // 매니저 ID
-    private Long managerId;
+    @OneToOne
+    @JoinColumn
+    private Manager manager;
 
     // 업무 가능 요일 (0: 일요일, 1: 월요일, ..., 6: 토요일)
-    private Integer dayOfWeek;
+    @Column
+    private DayOfWeek dayOfWeek;
 
     // 업무 시작 시간 (HH:mm 형식)
+    @Column
     private LocalTime time;
 }

--- a/member/src/main/java/com/kernel/member/domain/entity/Manager.java
+++ b/member/src/main/java/com/kernel/member/domain/entity/Manager.java
@@ -1,33 +1,94 @@
 package com.kernel.member.domain.entity;
 
+import com.kernel.global.domain.entity.File;
+import com.kernel.global.domain.entity.User;
 import com.kernel.member.common.enums.ContractStatus;
 
+import com.kernel.member.service.request.ManagerUpdateInfoReqDTO;
+import com.kernel.reservation.domain.entity.ServiceCategory;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 
+@Entity
+@Table(name = "manager")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@SuperBuilder
 public class Manager {
 
-    // 매니저 ID
-    private Long managerId;
+    @Id
+    private Long userId;
 
-    // 사용자 정보
-    private UserInfo userInfo;
+    // 매니저 ID
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId
+    @JoinColumn(name = "user_id")
+    private User user;
 
     // 특기
-    //private ServiceCategory specialty;
+    @ManyToOne
+    @JoinColumn
+    private ServiceCategory specialty;
 
     // 한 줄 소개
+    @Column(length = 50)
     private String bio;
 
     // 프로필 URL
-    private long profileImageFileId;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private File profileImageFileId;
 
     // 서류 파일 ID
-    // private File fileId;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private File fileId;
 
     // 계약상태
+    @Enumerated(EnumType.STRING)
+    @Column
     private ContractStatus contractStatus;
 
     // 계약 일시
+    @Column
     private LocalDateTime contractDate;
+
+    // Manager 정보 수정
+    public void update(ManagerUpdateInfoReqDTO request) {
+        if (request.getSpecialty() != null) {
+            this.specialty = request.getSpecialty();
+        }
+        if (request.getBio() != null) {
+            this.bio = request.getBio();
+        }
+    }
+
+    // 매니저 신청 승인
+    public void approve() {
+        this.contractStatus = ContractStatus.APPROVED;
+        this.contractDate = LocalDateTime.now();
+    }
+
+    // 매니저 신청 거절
+    public void reject() {
+        this.contractStatus = ContractStatus.REJECTED;
+    }
+
+    // 매니저 계약 해지 요청
+    public void requestTermination() {
+        this.contractStatus = ContractStatus.TERMINATION_PENDING;
+    }
+
+    // 매니저 계약 해지
+    public void terminate() {
+        this.contractStatus = ContractStatus.TERMINATED;
+    }
+
 }

--- a/member/src/main/java/com/kernel/member/domain/entity/ManagerStatistic.java
+++ b/member/src/main/java/com/kernel/member/domain/entity/ManagerStatistic.java
@@ -1,16 +1,42 @@
 package com.kernel.member.domain.entity;
 
-public class ManagerStatistic {
+import com.kernel.global.domain.entity.BaseEntity;
+import com.kernel.global.domain.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
 
-    // 매니저 ID
-    private Long managerId;
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "manager_statistic")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@SuperBuilder
+public class ManagerStatistic extends BaseEntity {
+
+    // 사용자 ID
+    @Id
+    private Long userId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId
+    @JoinColumn(name = "user_id")
+    private User user;
 
     // 예약 수
-    private Integer reservationCount;
+    @Column(nullable = false)
+    @Builder.Default
+    private Integer reservationCount = 0;
 
     // 리뷰 수
-    private Integer reviewCount;
+    @Column(nullable = false)
+    @Builder.Default
+    private Integer reviewCount = 0;
 
     // 매니저가 받은 별점 평균
-    private Double averageRating;
+    @Column(precision = 2, scale = 1)
+    @Builder.Default
+    private BigDecimal rating = BigDecimal.ZERO;
 }

--- a/member/src/main/java/com/kernel/member/domain/entity/ManagerTermination.java
+++ b/member/src/main/java/com/kernel/member/domain/entity/ManagerTermination.java
@@ -1,15 +1,45 @@
 package com.kernel.member.domain.entity;
 
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "manager_termination")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class ManagerTermination {
+
+    @Id
+    private Long userId;
+
     // 매니저 ID
-    private Long managerId;
+    @OneToOne
+    @MapsId
+    @JoinColumn(name = "user_id")
+    private Manager manager;
 
     // 계약 해지 요청 일시
-    private String requestDate;
+    @Column(nullable = false)
+    @CreationTimestamp
+    private LocalDateTime requestAt;
 
     // 계약 해지 사유
+    @Column(nullable = false, length = 300) // 계약 해지 사유는 최대 300자
     private String reason;
 
     // 계약 해지 일시
-    private String terminationDate;
+    @Column(nullable = false)
+    @UpdateTimestamp
+    private LocalDateTime terminatedAt;
+
+    // 계약 해지 테이블 업데이트
+    public void updateTerminatedAt(LocalDateTime terminatedAt) {
+        this.terminatedAt = terminatedAt;
+    }
 }

--- a/member/src/main/java/com/kernel/member/domain/entity/UserInfo.java
+++ b/member/src/main/java/com/kernel/member/domain/entity/UserInfo.java
@@ -31,6 +31,7 @@ public class UserInfo extends BaseEntity {
     private LocalDate birthDate;
 
     // 성별
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Gender gender;
 

--- a/member/src/main/java/com/kernel/member/repository/AvailableTImeRepository.java
+++ b/member/src/main/java/com/kernel/member/repository/AvailableTImeRepository.java
@@ -1,0 +1,12 @@
+package com.kernel.member.repository;
+
+import com.kernel.member.domain.entity.AvailableTime;
+import com.kernel.member.domain.entity.Manager;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AvailableTImeRepository extends JpaRepository<AvailableTime, Long> {
+    Optional<List<AvailableTime>> findByManager(Manager manager);
+}

--- a/member/src/main/java/com/kernel/member/repository/ManagerRepository.java
+++ b/member/src/main/java/com/kernel/member/repository/ManagerRepository.java
@@ -1,0 +1,18 @@
+package com.kernel.member.repository;
+
+import com.kernel.global.common.enums.UserStatus;
+import com.kernel.member.domain.entity.Manager;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ManagerRepository extends JpaRepository<Manager, Long> {
+
+    // TODO: 추후 admin에서 manager 조회 시 필요한 쿼리, 기존 코드에서 CustomeManagerRepository로 분리된 부분을 확인하고 필요에 따라 구현
+    /*Page<Manager> findByStatusNot(UserStatus status, Pageable pageable);
+    Page<Manager> findByUserNameContainingAndStatusNot(String keyword, UserStatus status, Pageable pageable);
+    Page<Manager> findByUserNameContaining(String keyword, Pageable pageable);
+    Page<Manager> findByStatus(UserStatus status, Pageable pageable);*/
+
+}

--- a/member/src/main/java/com/kernel/member/repository/ManagerTerminationRepository.java
+++ b/member/src/main/java/com/kernel/member/repository/ManagerTerminationRepository.java
@@ -1,0 +1,7 @@
+package com.kernel.member.repository;
+
+import com.kernel.member.domain.entity.ManagerTermination;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ManagerTerminationRepository extends JpaRepository<ManagerTermination, Long> {
+}

--- a/member/src/main/java/com/kernel/member/repository/MemberUserRepository.java
+++ b/member/src/main/java/com/kernel/member/repository/MemberUserRepository.java
@@ -2,14 +2,11 @@ package com.kernel.member.repository;
 
 import com.kernel.global.common.enums.UserStatus;
 import com.kernel.global.domain.entity.User;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDate;
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface MemberUserRepository extends JpaRepository<User, Long> {
 
     // phone 기반 사용자 존재 확인
     Boolean existsByPhone(String phone);

--- a/member/src/main/java/com/kernel/member/repository/UserInfoRepository.java
+++ b/member/src/main/java/com/kernel/member/repository/UserInfoRepository.java
@@ -8,5 +8,5 @@ import java.time.LocalDate;
 public interface UserInfoRepository extends JpaRepository<UserInfo, Long> {
 
     // userId, 생년월일 기반 UserInfo 조회 for Id 찾기
-    Boolean existByIdAndBirthDate(Long userId, LocalDate birthDate);
+    Boolean existsByUserIdAndBirthDate(Long userId, LocalDate birthDate);
 }

--- a/member/src/main/java/com/kernel/member/service/CustomerServiceImpl.java
+++ b/member/src/main/java/com/kernel/member/service/CustomerServiceImpl.java
@@ -16,7 +16,7 @@ import com.kernel.member.service.common.info.UserAccountInfo;
 import com.kernel.member.service.request.CustomerSignupReqDTO;
 import com.kernel.member.service.request.CustomerUpdateReqDTO;
 import com.kernel.member.service.response.CustomerDetailRspDTO;
-import com.kernel.member.service.response.CustomerDetailInfo;
+import com.kernel.member.service.common.info.CustomerDetailInfo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;

--- a/member/src/main/java/com/kernel/member/service/ManagerService.java
+++ b/member/src/main/java/com/kernel/member/service/ManagerService.java
@@ -1,0 +1,18 @@
+package com.kernel.member.service;
+
+import com.kernel.member.service.request.ManagerSignupReqDTO;
+import com.kernel.member.service.request.ManagerUpdateReqDTO;
+import com.kernel.member.service.response.ManagerDetailRspDTO;
+
+public interface ManagerService {
+
+    // 매니저 회원가입
+    void signup(ManagerSignupReqDTO request);
+
+    // 매니저 회원 정보 조회
+    ManagerDetailRspDTO getManager(Long userId);
+
+    // 매니저 회원 정보 수정
+    ManagerDetailRspDTO updateManager(Long userId, ManagerUpdateReqDTO updateReqDTO);
+
+}

--- a/member/src/main/java/com/kernel/member/service/ManagerServiceImpl.java
+++ b/member/src/main/java/com/kernel/member/service/ManagerServiceImpl.java
@@ -1,0 +1,156 @@
+package com.kernel.member.service;
+
+import com.kernel.global.common.enums.ErrorCode;
+import com.kernel.global.common.enums.UserRole;
+import com.kernel.global.common.enums.UserStatus;
+import com.kernel.global.common.exception.AuthException;
+import com.kernel.global.domain.entity.File;
+import com.kernel.global.domain.entity.User;
+import com.kernel.global.repository.FileRepository;
+import com.kernel.member.domain.entity.AvailableTime;
+import com.kernel.member.domain.entity.Manager;
+import com.kernel.member.domain.entity.UserInfo;
+import com.kernel.member.repository.AvailableTImeRepository;
+import com.kernel.member.repository.ManagerRepository;
+import com.kernel.member.service.common.UserInfoService;
+import com.kernel.member.service.common.UserService;
+import com.kernel.member.service.common.info.AvailableTimeInfo;
+import com.kernel.member.service.common.info.ManagerDetailInfo;
+import com.kernel.member.service.common.info.UserAccountInfo;
+import com.kernel.member.service.common.info.UserDetailInfo;
+import com.kernel.member.service.request.ManagerSignupReqDTO;
+import com.kernel.member.service.request.ManagerUpdateReqDTO;
+import com.kernel.member.service.response.ManagerDetailRspDTO;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class ManagerServiceImpl implements ManagerService {
+
+    private final UserService userService;
+    private final UserInfoService userInfoService;
+    private final ManagerRepository managerRepository;
+    private final AvailableTImeRepository availableTImeRepository;
+    private final FileRepository fileRepository;
+
+    /**
+     * 매니저 회원가입
+     *
+     * @param signupReqDTO 매니저 회원가입 요청 DTO
+     */
+    @Override
+    @Transactional
+    public void signup(ManagerSignupReqDTO signupReqDTO) {
+        // 1. phone 중복 검사
+        userService.validateDuplicatePhone(signupReqDTO.getUserSignupReqDTO().getPhone());
+
+        // 2. user 저장
+        User savedUser = userService.createUser(signupReqDTO.getUserSignupReqDTO(), UserRole.MANAGER);
+
+        // 3. userInfo 저장
+        UserInfo savedUserInfo = userInfoService.createUserInfo(signupReqDTO.getUserInfoSignupReqDTO(), savedUser);
+
+        // 4. AvailableTime 저장
+        List<AvailableTime> availableTimeList = signupReqDTO.toEntityList(signupReqDTO.getAvailableTimeReqDTOList());
+        availableTImeRepository.saveAll(availableTimeList);
+
+        // 5. Manager 저장
+        File file = fileRepository.findByFileId(signupReqDTO.getManagerReqDTO().getFileId())
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 파일입니다."));
+        File profileFile = fileRepository.findByFileId(signupReqDTO.getManagerReqDTO().getProfileImageFileId())
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로필 이미지 파일입니다."));
+
+        managerRepository.save(signupReqDTO.getManagerReqDTO().toEntity(signupReqDTO.getManagerReqDTO(), savedUser, file, profileFile));
+    }
+
+    /**
+     * 매니저 정보 조회
+     *
+     * @param userId 매니저 ID
+     * @return 매니저 상세 정보 DTO
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public ManagerDetailRspDTO getManager(Long userId) {
+        // 1. User 조회
+        User foundUser = userService.getByUserIdAndStatus(userId, UserStatus.ACTIVE);
+
+        // 2. UserInfo 조회
+        UserInfo foundUserInfo = userInfoService.getUserById(foundUser.getUserId());
+
+        // 3. Manager 조회
+        Manager foundManager = managerRepository.findById(foundUser.getUserId())
+                .orElseThrow(()-> new AuthException(ErrorCode.USER_NOT_FOUND));
+
+        // 4. Available Time 조회
+        List<AvailableTime> foundAvailableTimeList = availableTImeRepository.findByManager(foundManager)
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 매니저의 이용 가능 시간입니다."));
+
+        // 5. 응답 DTO 생성 및 반환
+        return ManagerDetailRspDTO.fromInfos(
+                UserAccountInfo.fromEntity(foundUser),
+                UserDetailInfo.fromEntity(foundUserInfo),
+                ManagerDetailInfo.fromEntity(foundManager),
+                AvailableTimeInfo.fromEntityList(foundAvailableTimeList)
+        );
+    }
+
+    /**
+     * 매니저 정보 수정
+     *
+     * @param userId 매니저 ID
+     * @param updateReqDTO 매니저 정보 수정 요청 DTO
+     * @return 수정된 매니저 상세 정보 DTO
+     */
+    @Override
+    @Transactional
+    public ManagerDetailRspDTO updateManager(Long userId,ManagerUpdateReqDTO updateReqDTO) {
+
+        // User 조회
+        User foundUser = userService.getByUserIdAndStatus(userId, UserStatus.ACTIVE);
+
+        // UserInfo 조회
+        UserInfo foundUserInfo = userInfoService.getUserById(foundUser.getUserId());
+
+        // Manager 조회
+        Manager foundManager = managerRepository.findById(foundUser.getUserId())
+                .orElseThrow(()-> new AuthException(ErrorCode.USER_NOT_FOUND));
+
+        // Available Time 조회
+        List<AvailableTime> foundAvailableTimeList = availableTImeRepository.findByManager(foundManager)
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 매니저의 이용 가능 시간입니다."));
+
+        // User 수정
+        foundUser.updateEmail(updateReqDTO.getUserUpdateReqDTO().getEmail());
+
+        // UserInfo 수정
+        foundUserInfo.updateAddress(
+                updateReqDTO.getUserInfoUpdateReqDTO().getRoadAddress(),
+                updateReqDTO.getUserInfoUpdateReqDTO().getDetailAddress(),
+                updateReqDTO.getUserInfoUpdateReqDTO().getLatitude(),
+                updateReqDTO.getUserInfoUpdateReqDTO().getLongitude()
+        );
+
+        // Manager 수정
+        foundManager.update(updateReqDTO.getManagerUpdateInfoReqDTO());
+
+        // Available Time 수정
+        availableTImeRepository.deleteAll(foundAvailableTimeList);
+        List<AvailableTime> updatedAvailableTimeList = updateReqDTO.toEntityList(updateReqDTO.getAvailableTimeUpdateReqDTOList());
+        availableTImeRepository.saveAll(updatedAvailableTimeList);
+
+        // DTO 변환 후 return
+        return ManagerDetailRspDTO.fromInfos(
+                UserAccountInfo.fromEntity(foundUser),
+                UserDetailInfo.fromEntity(foundUserInfo),
+                ManagerDetailInfo.fromEntity(foundManager),
+                AvailableTimeInfo.fromEntityList(updatedAvailableTimeList)
+        );
+    }
+}

--- a/member/src/main/java/com/kernel/member/service/ManagerTerminationService.java
+++ b/member/src/main/java/com/kernel/member/service/ManagerTerminationService.java
@@ -1,0 +1,11 @@
+package com.kernel.member.service;
+
+import com.kernel.member.service.request.ManagerTerminationReqDTO;
+import com.kernel.member.service.response.ManagerTerminationRspDTO;
+
+public interface ManagerTerminationService {
+
+    void requestTermination(Long managerId, ManagerTerminationReqDTO request);
+    ManagerTerminationRspDTO getTerminationDetails(Long managerId);
+
+}

--- a/member/src/main/java/com/kernel/member/service/ManagerTerminationServiceImpl.java
+++ b/member/src/main/java/com/kernel/member/service/ManagerTerminationServiceImpl.java
@@ -1,0 +1,70 @@
+package com.kernel.member.service;
+
+import com.kernel.global.domain.entity.User;
+import com.kernel.global.repository.UserRepository;
+import com.kernel.member.domain.entity.Manager;
+import com.kernel.member.domain.entity.ManagerTermination;
+import com.kernel.member.repository.ManagerRepository;
+import com.kernel.member.repository.ManagerTerminationRepository;
+import com.kernel.member.service.common.info.ManagerTerminationInfo;
+import com.kernel.member.service.request.ManagerTerminationReqDTO;
+import com.kernel.member.service.response.ManagerTerminationRspDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class ManagerTerminationServiceImpl implements ManagerTerminationService {
+
+    private final UserRepository userRepository;
+    private final ManagerRepository managerRepository;
+    private final ManagerTerminationRepository managerTerminationRepository;
+
+    /**
+     * 매니저 계약 해지 요청 처리
+     *
+     * @param managerId 매니저 ID
+     * @param request   계약 해지 요청 DTO
+     */
+    @Override
+    @Transactional
+    public void requestTermination(Long managerId, ManagerTerminationReqDTO request) {
+
+        // 1. 사용자 조회
+        User user = userRepository.findById(managerId)
+                .orElseThrow(() -> new NoSuchElementException("매니저를 찾을 수 없습니다."));
+
+        // 2. 매니저 조회
+        Manager manager = managerRepository.findById(managerId)
+                .orElseThrow(() -> new NoSuchElementException("매니저를 찾을 수 없습니다."));
+
+        // 3. 사용자, 매니저 상태 변경
+        manager.requestTermination();
+
+        // 4. 매니저 계약 해지 요청 저장
+        managerTerminationRepository.save(request.toEntity(manager, request));
+    }
+
+    /**
+     * 매니저 계약 해지 정보 조회
+     *
+     * @param managerId 매니저 ID
+     * @return 매니저 계약 해지 정보 DTO
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public ManagerTerminationRspDTO getTerminationDetails(Long managerId) {
+       // 1. 매니저 계약 해지 정보 조회
+        ManagerTermination termination = managerTerminationRepository.findById(managerId)
+                .orElseThrow(() -> new NoSuchElementException("매니저 계약 해지 정보를 찾을 수 없습니다."));
+
+        // 2. 필요한 필드만 Info 클래스로 추출
+        ManagerTerminationInfo terminationInfo = ManagerTerminationInfo.fromEntity(termination);
+
+        // 3. Info 클래스를 RspDTO로 변환
+        return ManagerTerminationRspDTO.fromInfo(terminationInfo);
+    }
+}

--- a/member/src/main/java/com/kernel/member/service/common/UserInfoServiceImpl.java
+++ b/member/src/main/java/com/kernel/member/service/common/UserInfoServiceImpl.java
@@ -47,6 +47,6 @@ public class UserInfoServiceImpl implements UserInfoService {
      */
     @Override
     public Boolean existByIdAndBirthDate(Long userId, LocalDate birthDate) {
-        return userInfoRepository.existByIdAndBirthDate(userId, birthDate);
+        return userInfoRepository.existsByUserIdAndBirthDate(userId, birthDate);
     }
 }

--- a/member/src/main/java/com/kernel/member/service/common/UserServiceImpl.java
+++ b/member/src/main/java/com/kernel/member/service/common/UserServiceImpl.java
@@ -6,7 +6,7 @@ import com.kernel.global.common.enums.UserStatus;
 import com.kernel.global.common.exception.AuthException;
 import com.kernel.global.domain.entity.User;
 import com.kernel.member.common.exception.DuplicateUserException;
-import com.kernel.member.repository.UserRepository;
+import com.kernel.member.repository.MemberUserRepository;
 import com.kernel.member.service.common.request.UserFindAccountReqDTO;
 import com.kernel.member.service.common.request.UserResetPwdReqDTO;
 import com.kernel.member.service.common.request.UserSignupReqDTO;
@@ -15,14 +15,13 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
 
-    private final UserRepository userRepository;
+    private final MemberUserRepository memberUserRepository;
     private final UserInfoService userInfoService;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
@@ -36,7 +35,7 @@ public class UserServiceImpl implements UserService {
     public Boolean findUserId(UserFindAccountReqDTO findAccountReqDTO) {
 
         // 사용자 조회
-        Optional<User> foundUser = userRepository.findByPhoneAndUserNameAndStatus(
+        Optional<User> foundUser = memberUserRepository.findByPhoneAndUserNameAndStatus(
                         findAccountReqDTO.getPhone(),         // 핸드폰번호
                         findAccountReqDTO.getUserName(),      // 사용자 이름
                         UserStatus.ACTIVE                     // 계정 상태
@@ -62,7 +61,7 @@ public class UserServiceImpl implements UserService {
     public String findUserPassword(UserFindAccountReqDTO findAccountReqDTO) {
 
         // 사용자 조회
-        User foundUser = userRepository.findByPhoneAndUserNameAndStatus(
+        User foundUser = memberUserRepository.findByPhoneAndUserNameAndStatus(
                 findAccountReqDTO.getPhone(),         // 핸드폰번호
                 findAccountReqDTO.getUserName(),      // 사용자 이름
                 UserStatus.ACTIVE                     // 계정 상태
@@ -97,7 +96,7 @@ public class UserServiceImpl implements UserService {
     public void resetPassword(Long userId, UserResetPwdReqDTO resetReqDTO) {
 
         // 사용자 조회
-        User foundUser = userRepository.findByUserIdAndStatus(userId, UserStatus.ACTIVE)
+        User foundUser = memberUserRepository.findByUserIdAndStatus(userId, UserStatus.ACTIVE)
                 .orElseThrow(()-> new AuthException(ErrorCode.USER_NOT_FOUND));
 
         // 비밀번호 일치 여부 확인
@@ -113,7 +112,7 @@ public class UserServiceImpl implements UserService {
      */
     @Override
     public void validateDuplicatePhone(String phone) {
-        if(userRepository.existsByPhone(phone)) {
+        if(memberUserRepository.existsByPhone(phone)) {
             throw new DuplicateUserException();
         }
     }
@@ -128,7 +127,7 @@ public class UserServiceImpl implements UserService {
     public void deleteUser(Long userId, String password) {
 
         // User 조회
-        User foundUser = userRepository.findByUserIdAndStatus(userId, UserStatus.ACTIVE)
+        User foundUser = memberUserRepository.findByUserIdAndStatus(userId, UserStatus.ACTIVE)
                 .orElseThrow(()-> new AuthException(ErrorCode.USER_NOT_FOUND));
 
         // 비밀번호 확인
@@ -150,7 +149,7 @@ public class UserServiceImpl implements UserService {
     public User createUser(UserSignupReqDTO reqDTO, UserRole userRole) {
 
         // Role 설정, 비밀번호 암호화 후 User 저장
-        return userRepository.save(reqDTO.toEntityWithRole(userRole, bCryptPasswordEncoder));
+        return memberUserRepository.save(reqDTO.toEntityWithRole(userRole, bCryptPasswordEncoder));
     }
 
     /**
@@ -161,7 +160,7 @@ public class UserServiceImpl implements UserService {
      */
     @Override
     public User getByUserIdAndStatus(Long userId, UserStatus userStatus) {
-        return userRepository.findByUserIdAndStatus(userId, userStatus)
+        return memberUserRepository.findByUserIdAndStatus(userId, userStatus)
                 .orElseThrow(()-> new AuthException(ErrorCode.USER_NOT_FOUND));
     }
 
@@ -174,7 +173,7 @@ public class UserServiceImpl implements UserService {
     public void checkPassword(Long userId, String password) {
 
         // User 조회
-        User foundUser = userRepository.findByUserIdAndStatus(userId, UserStatus.ACTIVE)
+        User foundUser = memberUserRepository.findByUserIdAndStatus(userId, UserStatus.ACTIVE)
                 .orElseThrow(()-> new AuthException(ErrorCode.USER_NOT_FOUND));
 
         // 비밀번호 확인

--- a/member/src/main/java/com/kernel/member/service/common/info/AvailableTimeInfo.java
+++ b/member/src/main/java/com/kernel/member/service/common/info/AvailableTimeInfo.java
@@ -1,0 +1,30 @@
+package com.kernel.member.service.common.info;
+
+import com.kernel.member.common.enums.DayOfWeek;
+import com.kernel.member.domain.entity.AvailableTime;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class AvailableTimeInfo {
+
+    // 업무 가능 요일
+    private DayOfWeek dayOfWeek;
+
+    // 업무 시작 시간 (HH:mm 형식)
+    private LocalTime time;
+
+    // List of available times from entity
+    public static List<AvailableTimeInfo> fromEntityList(List<AvailableTime> availableTimes) {
+        return availableTimes.stream()
+                .map(availableTime -> AvailableTimeInfo.builder()
+                        .dayOfWeek(availableTime.getDayOfWeek())
+                        .time(availableTime.getTime())
+                        .build())
+                .toList();
+    }
+}

--- a/member/src/main/java/com/kernel/member/service/common/info/CustomerDetailInfo.java
+++ b/member/src/main/java/com/kernel/member/service/common/info/CustomerDetailInfo.java
@@ -1,4 +1,4 @@
-package com.kernel.member.service.response;
+package com.kernel.member.service.common.info;
 
 
 import com.kernel.member.domain.entity.Customer;

--- a/member/src/main/java/com/kernel/member/service/common/info/ManagerDetailInfo.java
+++ b/member/src/main/java/com/kernel/member/service/common/info/ManagerDetailInfo.java
@@ -1,0 +1,46 @@
+package com.kernel.member.service.common.info;
+
+import com.kernel.global.domain.entity.File;
+import com.kernel.member.common.enums.ContractStatus;
+import com.kernel.member.domain.entity.Manager;
+import com.kernel.reservation.domain.entity.ServiceCategory;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ManagerDetailInfo {
+
+    // 특기
+    private ServiceCategory specialty;
+
+    // 한 줄 소개
+    private String bio;
+
+    // 프로필 URL
+    private String profileImageFilePath;
+
+    // 서류 파일 ID
+    private String filePaths;
+
+    // 계약상태
+    private ContractStatus contractStatus;
+
+    // 계약 일시
+    private LocalDateTime contractDate;
+
+    // Manager -> ManagerDetailInfo
+    public static ManagerDetailInfo fromEntity(Manager manager) {
+        return ManagerDetailInfo.builder()
+                .specialty(manager.getSpecialty())
+                .bio(manager.getBio())
+                .profileImageFilePath(manager.getProfileImageFileId() != null ? manager.getProfileImageFileId().getFilePathsJson() : null)
+                .filePaths(manager.getFileId() != null ? manager.getFileId().getFilePathsJson() : null)
+                .contractStatus(manager.getContractStatus())
+                .contractDate(manager.getContractDate())
+                .build();
+    }
+}

--- a/member/src/main/java/com/kernel/member/service/common/info/ManagerTerminationInfo.java
+++ b/member/src/main/java/com/kernel/member/service/common/info/ManagerTerminationInfo.java
@@ -1,0 +1,25 @@
+package com.kernel.member.service.common.info;
+
+import com.kernel.member.domain.entity.ManagerTermination;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ManagerTerminationInfo {
+    private LocalDateTime requestAt;
+    private LocalDateTime terminatedAt;
+    private String TerminationReason;
+
+    // Entity -> Info 변환 메서드
+    public static ManagerTerminationInfo fromEntity(ManagerTermination entity) {
+        return ManagerTerminationInfo.builder()
+                .requestAt(entity.getRequestAt())
+                .terminatedAt(entity.getTerminatedAt())
+                .TerminationReason(entity.getReason())
+                .build();
+    }
+
+}

--- a/member/src/main/java/com/kernel/member/service/common/info/UserAccountInfo.java
+++ b/member/src/main/java/com/kernel/member/service/common/info/UserAccountInfo.java
@@ -1,5 +1,6 @@
 package com.kernel.member.service.common.info;
 
+import com.kernel.global.common.enums.UserStatus;
 import com.kernel.global.domain.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,12 +22,16 @@ public class UserAccountInfo {
     // 이름
     private String userName;
 
+    // 계정 상태
+    private UserStatus status;
+
     // User -> UserAccountInfo
     public static UserAccountInfo fromEntity(User user) {
         return UserAccountInfo.builder()
                 .phone(user.getPhone())
                 .email(user.getEmail())
                 .userName(user.getUserName())
+                .status(user.getStatus())
                 .build();
     }
 

--- a/member/src/main/java/com/kernel/member/service/request/AvailableTimeReqDTO.java
+++ b/member/src/main/java/com/kernel/member/service/request/AvailableTimeReqDTO.java
@@ -1,0 +1,31 @@
+package com.kernel.member.service.request;
+
+import com.kernel.member.common.enums.DayOfWeek;
+
+import com.kernel.member.domain.entity.AvailableTime;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AvailableTimeReqDTO {
+
+    // 가능 요일
+    @NotNull(message = "요일은 필수입니다.")
+    private DayOfWeek dayOfWeek;
+
+    // 가능 시간
+    @NotNull(message = "가능 시간은 필수입니다.")
+    private LocalTime time;
+
+    // AvailableTimeReqDTO -> AvailableTime
+    public static AvailableTime toEntity(AvailableTimeReqDTO reqDTO) {
+        return AvailableTime.builder()
+                .dayOfWeek(reqDTO.getDayOfWeek())
+                .time(reqDTO.getTime())
+                .build();
+    }
+}

--- a/member/src/main/java/com/kernel/member/service/request/AvailableTimeUpdateReqDTO.java
+++ b/member/src/main/java/com/kernel/member/service/request/AvailableTimeUpdateReqDTO.java
@@ -1,0 +1,37 @@
+package com.kernel.member.service.request;
+
+import com.kernel.member.common.enums.DayOfWeek;
+import com.kernel.member.domain.entity.AvailableTime;
+import jakarta.validation.constraints.AssertTrue;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalTime;
+
+@Getter
+@Builder
+public class AvailableTimeUpdateReqDTO {
+
+    // 가능 요일
+    private DayOfWeek dayOfWeek;
+
+    // 가능 시간
+    private LocalTime time;
+
+    // 요일이 있을 때 시간은 필수
+    @AssertTrue(message = "요일이 있을 때 시간은 필수입니다.")
+    private boolean isTimeRequired() {
+        return dayOfWeek != null ? time != null : true;
+    }
+
+    // AvailableTimeUpdateReqDTO -> AvailableTime로 매핑
+    public static AvailableTime toEntity(AvailableTimeUpdateReqDTO availableTimeUpdateReqDTO) {
+        if (availableTimeUpdateReqDTO == null) {
+            return null;
+        }
+        return AvailableTime.builder()
+                .dayOfWeek(availableTimeUpdateReqDTO.getDayOfWeek())
+                .time(availableTimeUpdateReqDTO.getTime())
+                .build();
+    }
+}

--- a/member/src/main/java/com/kernel/member/service/request/ManagerReqDTO.java
+++ b/member/src/main/java/com/kernel/member/service/request/ManagerReqDTO.java
@@ -1,0 +1,45 @@
+package com.kernel.member.service.request;
+
+import com.kernel.global.domain.entity.File;
+import com.kernel.global.domain.entity.User;
+import com.kernel.member.domain.entity.Manager;
+import com.kernel.reservation.domain.entity.ServiceCategory;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ManagerReqDTO {
+
+    // 특기
+    @NotNull(message = "특기는 필수 입력입니다.")
+    private ServiceCategory specialty;
+
+    // 한 줄 소개
+    @NotBlank(message = "한 줄 소개는 필수 입력입니다.")
+    @Size(max = 50, message = "한 줄 소개는 최대 50자까지 입력 가능합니다.")
+    private String bio;
+
+    // 서류 파일 ID
+    @NotNull(message = "서류 파일 ID는 필수 입력입니다.")
+    private Long fileId;
+
+    // 프로필 사진 ID
+    @NotNull(message = "프로필 사진 ID는 필수 입력입니다.")
+    private Long profileImageFileId;
+
+    // ManagerReqDTO -> Manager
+    public static Manager toEntity(ManagerReqDTO reqDTO, User user, File file, File profileImageFile) {
+        return Manager.builder()
+                .user(user)
+                .specialty(reqDTO.getSpecialty())
+                .bio(reqDTO.getBio())
+                .fileId(file)
+                .profileImageFileId(profileImageFile)
+                .build();
+    }
+}

--- a/member/src/main/java/com/kernel/member/service/request/ManagerSignupReqDTO.java
+++ b/member/src/main/java/com/kernel/member/service/request/ManagerSignupReqDTO.java
@@ -1,0 +1,39 @@
+package com.kernel.member.service.request;
+
+import com.kernel.member.domain.entity.AvailableTime;
+import com.kernel.member.service.common.request.UserInfoSignupReqDTO;
+import com.kernel.member.service.common.request.UserSignupReqDTO;
+
+import jakarta.validation.Valid;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ManagerSignupReqDTO {
+
+    // User
+    @Valid
+    private UserSignupReqDTO userSignupReqDTO;
+
+    // UserInfo
+    @Valid
+    private UserInfoSignupReqDTO userInfoSignupReqDTO;
+
+    // Manager
+    @Valid
+    private ManagerReqDTO managerReqDTO;
+
+    // Available Time
+    @Valid
+    private List<AvailableTimeReqDTO> availableTimeReqDTOList;
+
+    // AvailableTimeReqDTO -> List<AvailableTime>로 매핑
+    @Builder
+    public static List<AvailableTime> toEntityList(List<AvailableTimeReqDTO> availableTimeReqDTOList) {
+        return availableTimeReqDTOList.stream()
+                .map(AvailableTimeReqDTO::toEntity)
+                .toList();
+    }
+}

--- a/member/src/main/java/com/kernel/member/service/request/ManagerTerminationReqDTO.java
+++ b/member/src/main/java/com/kernel/member/service/request/ManagerTerminationReqDTO.java
@@ -1,0 +1,24 @@
+package com.kernel.member.service.request;
+
+import com.kernel.member.domain.entity.Manager;
+import com.kernel.member.domain.entity.ManagerTermination;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class ManagerTerminationReqDTO {
+
+    // 계약 해지 사유
+    @NotBlank(message = "계약 해지 사유는 필수 입력입니다.")
+    @Size(max = 500)
+    private String terminationReason;
+
+    // ManagerTerminationReqDTO -> Entity 변환 메서드
+    public static ManagerTermination toEntity(Manager manager, ManagerTerminationReqDTO request) {
+        return ManagerTermination.builder()
+                .manager(manager)
+                .reason(request.getTerminationReason())
+                .build();
+    }
+}

--- a/member/src/main/java/com/kernel/member/service/request/ManagerUpdateInfoReqDTO.java
+++ b/member/src/main/java/com/kernel/member/service/request/ManagerUpdateInfoReqDTO.java
@@ -1,0 +1,18 @@
+package com.kernel.member.service.request;
+
+import com.kernel.reservation.domain.entity.ServiceCategory;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ManagerUpdateInfoReqDTO {
+
+    // 특기
+    private ServiceCategory specialty;
+
+    // 한 줄 소개
+    @Size(max = 50, message = "한 줄 소개는 최대 100자까지 입력 가능합니다.")
+    private String bio;
+}

--- a/member/src/main/java/com/kernel/member/service/request/ManagerUpdateReqDTO.java
+++ b/member/src/main/java/com/kernel/member/service/request/ManagerUpdateReqDTO.java
@@ -1,0 +1,40 @@
+package com.kernel.member.service.request;
+
+import com.kernel.member.domain.entity.AvailableTime;
+import com.kernel.member.service.common.request.UserInfoUpdateReqDTO;
+import com.kernel.member.service.common.request.UserUpdateReqDTO;
+import jakarta.validation.Valid;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ManagerUpdateReqDTO {
+
+    // User
+    @Valid
+    private UserUpdateReqDTO userUpdateReqDTO;
+
+    // UserInfo
+    @Valid
+    private UserInfoUpdateReqDTO userInfoUpdateReqDTO;
+
+    // Manager
+    @Valid
+    private ManagerUpdateInfoReqDTO managerUpdateInfoReqDTO;
+
+    // Available Time
+    @Valid
+    private List<AvailableTimeUpdateReqDTO> availableTimeUpdateReqDTOList;
+
+    // List<AvailableTimeUpdateReqDTO> -> List<AvailableTime>로 매핑
+    @Builder
+    public static List<AvailableTime> toEntityList(List<AvailableTimeUpdateReqDTO> availableTimeReqDTOList) {
+        return availableTimeReqDTOList.stream()
+                .map(AvailableTimeUpdateReqDTO::toEntity)
+                .toList();
+    }
+
+}

--- a/member/src/main/java/com/kernel/member/service/response/AvailableTimeRspDTO.java
+++ b/member/src/main/java/com/kernel/member/service/response/AvailableTimeRspDTO.java
@@ -1,0 +1,19 @@
+package com.kernel.member.service.response;
+
+import java.time.LocalTime;
+
+import com.kernel.member.common.enums.DayOfWeek;
+import lombok.Getter;
+
+@Getter
+public class AvailableTimeRspDTO {
+
+    // 가능시간ID
+    private Long timeId;
+
+    // 가능 요일
+    private DayOfWeek dayOfWeek;
+
+    // 가능 시간
+    private LocalTime time;
+}

--- a/member/src/main/java/com/kernel/member/service/response/CustomerDetailRspDTO.java
+++ b/member/src/main/java/com/kernel/member/service/response/CustomerDetailRspDTO.java
@@ -1,6 +1,7 @@
 package com.kernel.member.service.response;
 
 import com.kernel.member.common.enums.Gender;
+import com.kernel.member.service.common.info.CustomerDetailInfo;
 import com.kernel.member.service.common.info.UserDetailInfo;
 import com.kernel.member.service.common.info.UserAccountInfo;
 import lombok.AllArgsConstructor;

--- a/member/src/main/java/com/kernel/member/service/response/ManagerDetailRspDTO.java
+++ b/member/src/main/java/com/kernel/member/service/response/ManagerDetailRspDTO.java
@@ -1,0 +1,99 @@
+package com.kernel.member.service.response;
+
+import com.kernel.global.common.enums.UserStatus;
+import com.kernel.member.common.enums.Gender;
+
+import com.kernel.member.service.common.info.AvailableTimeInfo;
+import com.kernel.member.service.common.info.ManagerDetailInfo;
+import com.kernel.member.service.common.info.UserAccountInfo;
+import com.kernel.member.service.common.info.UserDetailInfo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ManagerDetailRspDTO {
+
+    /* User */
+    // 연락처(=계정ID)
+    private String phone;
+
+    // 이메일
+    private String email;
+
+    // 이름
+    private String userName;
+
+    /* UserInfo */
+    // 생년월일
+    private LocalDate birthDate;
+
+    // 성별
+    private Gender gender;
+
+    // 위도
+    private BigDecimal latitude;
+
+    // 경도
+    private BigDecimal longitude;
+
+    // 도로명 주소
+    private String roadAddress;
+
+    // 상세 주소
+    private String detailAddress;
+
+    /* Manager */
+    // 한줄소개
+    private String bio;
+
+    // 프로필이미지 경로
+    private String profileImagePath;
+
+    // 첨부파일 경로
+    private String filePaths;
+
+    // 계정 상태
+    private UserStatus status;
+
+    // 계약일시
+    private LocalDateTime contractAt;
+
+    // 업무가능시간
+    private List<AvailableTimeInfo> availableTimes;
+
+    // Info -> DTO 변환
+    public static ManagerDetailRspDTO fromInfos(
+            UserAccountInfo userAccountInfo,
+            UserDetailInfo userDetailInfo,
+            ManagerDetailInfo managerDetailInfo,
+            List<AvailableTimeInfo> availableTimes
+    ) {
+        return ManagerDetailRspDTO.builder()
+                .phone(userAccountInfo.getPhone())
+                .email(userAccountInfo.getEmail())
+                .userName(userAccountInfo.getUserName())
+                .birthDate(userDetailInfo.getBirthDate())
+                .gender(userDetailInfo.getGender())
+                .latitude(userDetailInfo.getLatitude())
+                .longitude(userDetailInfo.getLongitude())
+                .roadAddress(userDetailInfo.getRoadAddress())
+                .detailAddress(userDetailInfo.getDetailAddress())
+                .bio(managerDetailInfo.getBio())
+                .profileImagePath(managerDetailInfo.getProfileImageFilePath() != null ? managerDetailInfo.getProfileImageFilePath() : "")
+                .filePaths(managerDetailInfo.getFilePaths() != null ? managerDetailInfo.getFilePaths() : "")
+                .status(userAccountInfo.getStatus())
+                .contractAt(managerDetailInfo.getContractDate())
+                .availableTimes(availableTimes)
+                .build();
+    }
+}

--- a/member/src/main/java/com/kernel/member/service/response/ManagerTerminationRspDTO.java
+++ b/member/src/main/java/com/kernel/member/service/response/ManagerTerminationRspDTO.java
@@ -1,0 +1,31 @@
+package com.kernel.member.service.response;
+
+import com.kernel.member.service.common.info.ManagerTerminationInfo;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ManagerTerminationRspDTO {
+
+    // 계약 해지 요청 일시
+    private LocalDateTime requestedAt;
+
+    // 계약 해지 일시
+    private LocalDateTime terminatedAt;
+
+    // 계약 해지 사유
+    private String TerminationReason;
+
+    // Info -> ManagerTerminationRspDTO 변환 메서드
+    public static ManagerTerminationRspDTO fromInfo(ManagerTerminationInfo info) {
+        return ManagerTerminationRspDTO.builder()
+                .requestedAt(info.getRequestAt())
+                .terminatedAt(info.getTerminatedAt())
+                .TerminationReason(info.getTerminationReason())
+                .build();
+    }
+
+}

--- a/reservation/build.gradle
+++ b/reservation/build.gradle
@@ -18,7 +18,7 @@ repositories {
 }
 
 dependencies {
-
+    // Module dependencies
     implementation project(':global')
 
     // Spring Boot dependencies

--- a/reservation/src/main/java/com/kernel/reservation/repository/CleaningLogRepository.java
+++ b/reservation/src/main/java/com/kernel/reservation/repository/CleaningLogRepository.java
@@ -1,0 +1,15 @@
+package com.kernel.reservation.repository;
+
+import com.kernel.reservation.domain.entity.CleaningLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CleaningLogRepository extends JpaRepository<CleaningLog, Long> {
+
+    // 예약ID로 존재 여부 확인
+    Boolean existsByReservation_ReservationId(Long reservationId);
+
+    // 예약ID로 조회
+    CleaningLog findByReservation_ReservationId(Long reservationId);
+}


### PR DESCRIPTION
## ✅ 작업 유형

- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactor)

---

## 🔍 작업 내용

<!-- 어떤 작업을 했는지 구체적으로 적어주세요 (코드, 로직, 예외 처리 등) -->
- Manager 기본 기능 리펙토링
  - Manager 지원, 정보 조회, 정보 수정, 계약해지 요청
  - Manager 계약 상태에 APPROVED Enum 추가
- 회원가입, 로그인 오류 수정
  - CustomerUserDetailService에서 UserRepository를 final로 지정해 생성자 주입이 가능하도록 수정
  - JWT에서 role을 추출해 User를 빌드하도록 수정
    - 로그인 후 사용자의 role이 확인되지 않는 문제가 있었음 
---

## 💬 리뷰요청

<!-- 리뷰어가 참고하면 좋을 내용, 고민한 점 등을 자유롭게 작성해주세요 -->
- SecurityUrlConstants의 PUBLIC_URLS에 로그인 관련 URL이 포함되어 있어, 해당 요청이 SecurityConfig의 commonFilterChain에서 처리되며 우선순위가 낮은 customerFilterChain이나 managerFilterChain에서 CustomLoginFilter가 호출되지 않는 문제가 있었습니다. 현재는 임시 방안으로 SecurityUrlConstants에서 로그인 관련 URL을 주석 처리해 우회하고 있지만, 장기적으로는 commonFilterChain에서 CustomLoginFilter를 처리하도록 구성하는 것이 어떨지 고민하고 있습니다.

- 이에 대해 다음과 같은 부분에 대한 의견을 부탁드립니다:
  - CustomLoginFilter를 commonFilterChain에 등록해도 인증 흐름상 문제가 없을지
  - 각 역할별 FilterChain에서 처리하던 로그인 흐름을 공통 FilterChain으로 옮길 때 예상되는 영향이나 고려할 점
  - 혹시 더 적절한 구조나 권한 분리를 유지하면서도 CustomLoginFilter가 정상 작동할 수 있는 다른 방식이 있다면 제안 부탁드립니다

---

## 📎 관련 이슈

<!-- 관련된 이슈 번호가 있다면 연결해주세요 -->
Closes #177 

