### PR TITLE
[Refactor] Reservation 모듈의 manager 예약 조회 기능 리펙토링

### DIFF
--- a/api/src/main/java/com/kernel/app/repository/AdminAuthRepository.java
+++ b/api/src/main/java/com/kernel/app/repository/AdminAuthRepository.java
@@ -1,0 +1,13 @@
+package com.kernel.app.repository;
+
+import com.kernel.common.admin.entity.Admin;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AdminAuthRepository extends JpaRepository<Admin, Long> {
+
+    Boolean existsByPhone(String email);
+
+    Optional<Admin> findByPhone(String email);
+}

--- a/evaluation/src/main/java/com/kernel/evaluation/repository/feedback/CustomerFeedbackRepository.java
+++ b/evaluation/src/main/java/com/kernel/evaluation/repository/feedback/CustomerFeedbackRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 public interface CustomerFeedbackRepository extends JpaRepository<Feedback, Long>, CustomCustomerFeedbackRepository {
 
     // 피드백 조회(where feedbackId, customerId, managerId)
-    Optional<Feedback> findByCustomer_CustomerIdAndManager_ManagerId(Long customerId, Long managerId);
+    Optional<Feedback> findByCustomer_UserIdAndManager_UserId(Long customerId, Long managerId);
 }

--- a/evaluation/src/main/java/com/kernel/evaluation/repository/review/ManagerReviewRepository.java
+++ b/evaluation/src/main/java/com/kernel/evaluation/repository/review/ManagerReviewRepository.java
@@ -10,6 +10,6 @@ import org.springframework.stereotype.Repository;
 public interface ManagerReviewRepository extends JpaRepository<Review, Long>, CustomManagerReviewRepository {
 
     // 리뷰 존재 여부 확인(작성자 유형, 작성자ID(=매니저ID), 예약ID 기준)
-    Boolean existsByAuthorTypeAndAuthorIdAndReservation_ReservationId(ReviewAuthorType reviewAuthorType, Long managerId, Long reservationId);
+    Boolean existsByReviewAuthorTypeAndAuthorIdAndReservation_ReservationId(ReviewAuthorType reviewAuthorType, Long managerId, Long reservationId);
 
 }

--- a/evaluation/src/main/java/com/kernel/evaluation/service/feedback/CustomerFeedbackServiceImpl.java
+++ b/evaluation/src/main/java/com/kernel/evaluation/service/feedback/CustomerFeedbackServiceImpl.java
@@ -57,7 +57,7 @@ public class CustomerFeedbackServiceImpl implements CustomerFeedbackService {
 */
         // 피드백 존재 여부
         Optional<Feedback> foundFeedbackOpt
-                = customerFeedbackRepository.findByCustomer_CustomerIdAndManager_ManagerId(userId, reqDTO.getManagerId());
+                = customerFeedbackRepository.findByCustomer_UserIdAndManager_UserId(userId, reqDTO.getManagerId());
 
         Feedback savedFeedback;
 

--- a/evaluation/src/main/java/com/kernel/evaluation/service/review/ManagerReviewServiceImpl.java
+++ b/evaluation/src/main/java/com/kernel/evaluation/service/review/ManagerReviewServiceImpl.java
@@ -66,7 +66,7 @@ public class ManagerReviewServiceImpl implements ManagerReviewService {
         }
 */
         // 2. 등록된 리뷰가 존재하는지 확인
-        if (managerReviewRepository.existsByAuthorTypeAndAuthorIdAndReservation_ReservationId(ReviewAuthorType.MANAGER, userId, reservationId)) {
+        if (managerReviewRepository.existsByReviewAuthorTypeAndAuthorIdAndReservation_ReservationId(ReviewAuthorType.MANAGER, userId, reservationId)) {
             throw new IllegalStateException("이미 등록된 리뷰가 존재합니다.");
         }
 

--- a/reservation/src/main/java/com/kernel/reservation/controller/ManagerReservationController.java
+++ b/reservation/src/main/java/com/kernel/reservation/controller/ManagerReservationController.java
@@ -1,0 +1,72 @@
+package com.kernel.reservation.controller;
+
+import com.kernel.global.common.enums.UserStatus;
+import com.kernel.global.security.CustomUserDetails;
+import com.kernel.global.service.dto.response.ApiResponse;
+import com.kernel.reservation.service.ManagerReservationService;
+import com.kernel.reservation.service.request.ManagerReservationSearchCondDTO;
+import com.kernel.reservation.service.response.ManagerReservationRspDTO;
+import com.kernel.reservation.service.response.ManagerReservationSummaryRspDTO;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/managers/reservations")
+@RequiredArgsConstructor
+public class ManagerReservationController {
+
+    public final ManagerReservationService reservationService;
+
+    /**
+     * 매니저에게 할당된 예약 목록 조회 API (검색 조건 및 페이징 처리)
+     * @param manager 매니저
+     * @param searchCondDTO 검색조건DTO
+     * @param pageable 페이징
+     * @return 검색 조건에 따른 매니저에게 할당된 예약 목록을 응답 (페이징 포함)
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<ManagerReservationSummaryRspDTO>>> searchManagerReservations(
+            @AuthenticationPrincipal CustomUserDetails manager,
+            @ModelAttribute ManagerReservationSearchCondDTO searchCondDTO,
+            Pageable pageable
+    ) {
+        if (!UserStatus.ACTIVE.equals(manager.getStatus())) {
+            throw new AccessDeniedException(
+                "죄송합니다. 현재 계정 상태에서는 해당 요청을 처리할 수 없습니다. (상태: " + manager.getStatus() + ")"
+            );
+        }
+        Page<ManagerReservationSummaryRspDTO> responseDTOPage
+            = reservationService.searchManagerReservationsWithPaging(manager.getUserId(), searchCondDTO, pageable);
+        return ResponseEntity.ok(new ApiResponse<>(true, "매니저 예약 목록 조회 성공", responseDTOPage));
+    }
+
+    /**
+     * 매니저에게 할당된 예약 상세 조회 API
+     * @param manager 매니저
+     * @param reservationId
+     * @return 매니저에게 할당된 예약 상세 정보를 담은 응답
+     */
+    @GetMapping("/{reservation-id}")
+    public ResponseEntity<ApiResponse<ManagerReservationRspDTO>> getManagerReservation(
+        @AuthenticationPrincipal CustomUserDetails manager,
+        @PathVariable("reservation-id") Long reservationId
+    ) {
+        if (!UserStatus.ACTIVE.equals(manager.getStatus())) {
+            throw new AccessDeniedException(
+                "죄송합니다. 현재 계정 상태에서는 해당 요청을 처리할 수 없습니다. (상태: " + manager.getStatus() + ")"
+            );
+        }
+        ManagerReservationRspDTO responseDTO = reservationService.getManagerReservation(manager.getUserId(), reservationId);
+        return ResponseEntity.ok(new ApiResponse<>(true, "매니저 예약 상세 조회 성공", responseDTO));
+    }
+}

--- a/reservation/src/main/java/com/kernel/reservation/domain/entity/ServiceCheckLog.java
+++ b/reservation/src/main/java/com/kernel/reservation/domain/entity/ServiceCheckLog.java
@@ -18,8 +18,11 @@ import java.sql.Timestamp;
 @SuperBuilder
 public class ServiceCheckLog extends BaseEntity {
 
-    // 예약 ID
+    // 체크로그 ID
     @Id
+    private Long reservationId;
+
+    // 예약 ID
     @MapsId
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reservation_id", nullable = false)

--- a/reservation/src/main/java/com/kernel/reservation/domain/enums/MatchStatus.java
+++ b/reservation/src/main/java/com/kernel/reservation/domain/enums/MatchStatus.java
@@ -1,9 +1,10 @@
 package com.kernel.reservation.domain.enums;
 
 public enum MatchStatus {
-    PENDING("대기중"),
-    MATCHED("매칭됨"),
-    REJECTED("거절됨");
+    PENDING("대기"),
+    MATCHED("매니저 수용"),
+    REJECTED("매니저 불수용"),
+    RESERVATION_CANCELED("예약 취소");
 
     private final String label;
 

--- a/reservation/src/main/java/com/kernel/reservation/repository/CustomManagerReservationRepository.java
+++ b/reservation/src/main/java/com/kernel/reservation/repository/CustomManagerReservationRepository.java
@@ -1,0 +1,19 @@
+package com.kernel.reservation.repository;
+
+import com.kernel.reservation.service.info.ManagerReservationDetailInfo;
+import com.kernel.reservation.service.info.ManagerReservationSummaryInfo;
+import com.kernel.reservation.service.request.ManagerReservationSearchCondDTO;
+import com.kernel.reservation.service.response.ManagerReservationRspDTO;
+
+import com.querydsl.core.Tuple;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomManagerReservationRepository {
+
+    // 매니저에게 할당된 예약 목록 조회 (검색조건 및 페이징 처리)
+    Page<ManagerReservationSummaryInfo> searchManagerReservationsWithPaging(Long managerId, ManagerReservationSearchCondDTO searchCondDTO, Pageable pageable);
+
+    // 매니저에게 할당된 예약 상세 조회(매니저ID와 예약ID로 조회)
+    ManagerReservationDetailInfo findByManagerIdAndReservationId(Long managerId, Long reservationId);
+}

--- a/reservation/src/main/java/com/kernel/reservation/repository/CustomManagerReservationRepositoryImpl.java
+++ b/reservation/src/main/java/com/kernel/reservation/repository/CustomManagerReservationRepositoryImpl.java
@@ -1,0 +1,234 @@
+package com.kernel.reservation.repository;
+
+import com.kernel.global.common.enums.UserRole;
+import com.kernel.global.domain.entity.QUser;
+import com.kernel.reservation.common.enums.MatchStatus;
+import com.kernel.reservation.domain.entity.*;
+import com.kernel.reservation.domain.enums.ReservationStatus;
+import com.kernel.reservation.service.info.ManagerReservationDetailInfo;
+import com.kernel.reservation.service.info.ManagerReservationSummaryInfo;
+import com.kernel.reservation.service.request.ManagerReservationSearchCondDTO;
+
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQueryFactory;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomManagerReservationRepositoryImpl implements CustomManagerReservationRepository {
+
+    private final JPQLQueryFactory jpaQueryFactory;
+
+    /**
+     * 매니저에게 할당된 예약 목록 조회 (검색 조건 및 페이징 처리)
+     * @param managerId 매니저ID
+     * @param searchCondDTO 검색조건DTO
+     * @param pageable 페이징
+     * @return 조건에 맞는 예약 정보를 담은 Page 객체
+     */
+    @Override
+    public Page<ManagerReservationSummaryInfo> searchManagerReservationsWithPaging(
+            Long managerId, ManagerReservationSearchCondDTO searchCondDTO, Pageable pageable
+    ) {
+        QReservation reservation = QReservation.reservation;
+        QReservationSchedule reservationSchedule = QReservationSchedule.reservationSchedule;
+        QServiceCheckLog serviceCheckLog = QServiceCheckLog.serviceCheckLog;
+        QReservationMatch reservationMatch = QReservationMatch.reservationMatch;
+        // QReview review = QReview.review; // 클라이언트에서 review 조회 api를 사용해서 따로 조회
+
+        // 전체 개수 조회
+        long total = Optional.ofNullable(
+            jpaQueryFactory
+                .select(reservation.count())
+                .from(reservation)
+                .leftJoin(reservationSchedule).on(reservationSchedule.reservation.reservationId.eq(reservation.reservationId))
+                .leftJoin(serviceCheckLog).on(serviceCheckLog.reservation.reservationId.eq(reservation.reservationId))
+                .leftJoin(reservationMatch).on(reservationMatch.reservation.reservationId.eq(reservation.reservationId))
+                .where(
+                    managerEq(managerId, reservation.reservationId.longValue(), reservationMatch), // 매니저 ID 일치
+                    RequestDateGoe(searchCondDTO.getFromRequestDate()),         // 청소 예약 날짜 >= 시작일
+                    RequestDateLoe(searchCondDTO.getToRequestDate()),           // 청소 예약 날짜 <= 종료일
+                    reservationStatus(searchCondDTO.getReservationStatus()),    // 예약 상태
+                    isCheckedIn(searchCondDTO.getIsCheckedIn()),                // 체크인 여부
+                    isCheckedOut(searchCondDTO.getIsCheckedOut()),              // 체크아웃 여부
+                    customerNameLike(searchCondDTO.customerNameKeyword)         // 고객명 검색어 포함
+                )
+                .fetchOne()
+        ).orElse(0L);
+
+        // 페이지 결과 조회
+        List<ManagerReservationSummaryInfo> results = jpaQueryFactory
+                .select(Projections.fields(ManagerReservationSummaryInfo.class,
+                        reservation.reservationId,
+                        reservationSchedule.requestDate,
+                        reservationSchedule.startTime,
+                        reservationSchedule.turnaround,
+                        reservation.user.userId,
+                        reservation.serviceCategory.serviceName,
+                        reservation.status,
+                        serviceCheckLog.reservation,
+                        Expressions.booleanTemplate("CASE WHEN {0} IS NOT NULL THEN true ELSE false END", serviceCheckLog.inTime).as("isCheckedIn"),
+                        serviceCheckLog.inTime,
+                        Expressions.booleanTemplate("CASE WHEN {0} IS NOT NULL THEN true ELSE false END", serviceCheckLog.outTime).as("isCheckedOut"),
+                        serviceCheckLog.outTime
+                ))
+                .from(reservation)
+                .leftJoin(reservationSchedule).on(reservationSchedule.reservation.reservationId.eq(reservation.reservationId))
+                .leftJoin(serviceCheckLog).on(serviceCheckLog.reservation.reservationId.eq(reservation.reservationId))
+                .leftJoin(reservationMatch).on(reservationMatch.reservation.reservationId.eq(reservation.reservationId))
+                .where(
+                        managerEq(managerId, reservation.reservationId.longValue(), reservationMatch),
+                        RequestDateGoe(searchCondDTO.getFromRequestDate()),
+                        RequestDateLoe(searchCondDTO.getToRequestDate()),
+                        reservationStatus(searchCondDTO.getReservationStatus()),
+                        isCheckedIn(searchCondDTO.getIsCheckedIn()),
+                        isCheckedOut(searchCondDTO.getIsCheckedOut()),
+                        customerNameLike(searchCondDTO.customerNameKeyword)
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(reservation.reservationId.desc())
+                .fetch();
+
+        return new PageImpl<>(results, pageable, total);
+    }
+
+    /**
+     * 매니저에게 할당된 예약 상세 조회
+     * @param managerId 매니저ID
+     * @param reservationId 예약ID
+     * @return 매니저 예약 상세 정보 DTO
+     */
+    @Override
+    public ManagerReservationDetailInfo findByManagerIdAndReservationId(
+        Long managerId, Long reservationId
+    ) {
+        QReservation reservation = QReservation.reservation;
+        QReservationSchedule reservationSchedule = QReservationSchedule.reservationSchedule;
+        QReservationMatch reservationMatch = QReservationMatch.reservationMatch;
+        // QCustomer customer = QCustomer.customer; // 클라이언트에서 UserInfo 조회 API를 사용해서 따로 조회
+        QServiceCheckLog serviceCheckLog = QServiceCheckLog.serviceCheckLog;
+        // QReview customerReview = new QReview("customerReview"); // 클라이언트에서 review 조회 api를 사용해서 따로 조회
+        // QReview managerReview = new QReview("managerReview"); // 클라이언트에서 review 조회 api를 사용해서 따로 조회
+        QServiceCategory serviceCategory = QServiceCategory.serviceCategory;
+        QExtraService extraService = QExtraService.extraService;
+
+
+        // 추가 서비스 조회
+        Expression<String> extraServiceNameExpr = ExpressionUtils.as(
+            JPAExpressions
+                .select(
+                    Expressions.stringTemplate(
+                        "COALESCE(GROUP_CONCAT({0}), '-')",
+                        serviceCategory.serviceName
+                    )
+                )
+                .from(extraService)
+                //.leftJoin(serviceCategory).on(serviceCategory.serviceId.eq(extraService.serviceCategory.serviceId)) -> serviceCategory가 extraService에 포함되는 여부 판단 필요
+                .where(extraService.reservation.reservationId.eq(reservation.reservationId)),
+            "extraServiceName"
+        );
+
+        return jpaQueryFactory
+            .select(Projections.fields(ManagerReservationDetailInfo.class,
+                reservation.reservationId,
+                reservationSchedule.requestDate,
+                reservationSchedule.startTime,
+                reservationSchedule.turnaround,
+                reservation.serviceCategory.serviceName,
+                reservation.status,
+                reservation.user.userId,
+                extraServiceNameExpr,
+                reservation.memo,
+                serviceCheckLog.reservation,
+                serviceCheckLog.inTime,
+                serviceCheckLog.inFileId,
+                serviceCheckLog.outTime,
+                serviceCheckLog.outFileId
+            ))
+            .from(reservation)
+            .leftJoin(reservation.user).on(reservation.user.role.eq(UserRole.CUSTOMER))
+            .leftJoin(reservationSchedule).on(reservationSchedule.reservation.reservationId.eq(reservation.reservationId))
+            .leftJoin(serviceCheckLog).on(serviceCheckLog.reservation.reservationId.eq(reservation.reservationId))
+            .leftJoin(reservationMatch).on(reservationMatch.reservation.reservationId.eq(reservation.reservationId))
+            .where(
+                reservation.reservationId.eq(reservationId),
+                managerEq(managerId, reservation.reservationId, reservationMatch) // 예약 매치 테이블에서 예약 ID가 reservationId와 일치하고 매칭상태가 MATCHED인 매니저 ID가 필요
+            )
+            .fetchOne();
+    }
+
+    // 매니저 ID 일치 ->  예약 매치 테이블에서 예약 ID가 reservationId와 일치하고 매칭상태가 MATCHED인 매니저 ID가 필요
+    private BooleanExpression managerEq(Long managerId, NumberExpression<Long> reservationId, QReservationMatch reservationMatch) {
+        return QUser.user.userId.eq(managerId)
+                .and(QUser.user.role.eq(UserRole.MANAGER))
+                .and(reservationMatch.reservation.reservationId.eq(reservationId))
+                .and(reservationMatch.status.eq(MatchStatus.MATCHED));
+    }
+
+    // 청소 예약 날짜 >= 시작일
+    private BooleanExpression RequestDateGoe(LocalDate from) {
+        return from != null
+            ? QReservationSchedule.reservationSchedule.requestDate.goe(from)
+            : null;
+    }
+
+    // 청소 예약 날짜 <= 종료일
+    private BooleanExpression RequestDateLoe(LocalDate to) {
+        return to != null
+            ? QReservationSchedule.reservationSchedule.requestDate.loe(to)
+            : null;
+    }
+
+    // 예약 상태
+    private BooleanExpression reservationStatus(List<ReservationStatus> statuses) {
+        return (statuses != null && !statuses.isEmpty())
+            ? QReservation.reservation.status.in(statuses)
+            : null;
+    }
+
+    // 체크인 여부
+    private BooleanExpression isCheckedIn(Boolean isCheckedIn) {
+        if (isCheckedIn == null) return null;
+        return isCheckedIn
+            ? QServiceCheckLog.serviceCheckLog.inTime.isNotNull()
+            : QServiceCheckLog.serviceCheckLog.inTime.isNull();
+    }
+
+    // 체크아웃 여부
+    private BooleanExpression isCheckedOut(Boolean isCheckedOut) {
+        if (isCheckedOut == null) return null;
+        return isCheckedOut
+            ? QServiceCheckLog.serviceCheckLog.outTime.isNotNull()
+            : QServiceCheckLog.serviceCheckLog.outTime.isNull();
+    }
+
+    /* // 리뷰 작성 여부 -> 클라이언트에서 review 조회 api를 사용해서 따로 조회
+    private BooleanExpression isReviewed(Boolean isReviewed) {
+        if (isReviewed == null) return null;
+        return isReviewed
+            ? QReview.review.reviewId.isNotNull()
+            : QReview.review.reviewId.isNull();
+    }*/
+
+    // 고객명 검색어 포함 -> 검색된 이름 중에 role이 CUSTOMER인 경우만 조회 필요
+    private BooleanExpression customerNameLike(String keyword) {
+        return (keyword != null && !keyword.isBlank())
+            ? QReservation.reservation.user.userName.eq(keyword)
+                .and(QReservation.reservation.user.role.eq(UserRole.CUSTOMER))
+            : null;
+    }
+}

--- a/reservation/src/main/java/com/kernel/reservation/repository/ManagerReservationRepository.java
+++ b/reservation/src/main/java/com/kernel/reservation/repository/ManagerReservationRepository.java
@@ -1,0 +1,10 @@
+package com.kernel.reservation.repository;
+
+
+import com.kernel.reservation.domain.entity.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ManagerReservationRepository extends JpaRepository<Reservation, Long>, CustomManagerReservationRepository {
+}

--- a/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationService.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationService.java
@@ -1,0 +1,28 @@
+package com.kernel.reservation.service;
+
+
+import com.kernel.reservation.service.request.ManagerReservationSearchCondDTO;
+import com.kernel.reservation.service.response.ManagerReservationRspDTO;
+import com.kernel.reservation.service.response.ManagerReservationSummaryRspDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ManagerReservationService {
+
+    /**
+     * 매니저에게 할당된 예약 목록 조회 (검색조건 및 페이징 처리)
+     * @param managerId 매니저ID
+     * @param searchCondDTO 검색조건DTO
+     * @param pageable 페이징
+     * @return 조회된 매니저에게 할당된 예약 목록을 담은 응답
+     */
+    Page<ManagerReservationSummaryRspDTO> searchManagerReservationsWithPaging(Long managerId, ManagerReservationSearchCondDTO searchCondDTO, Pageable pageable);
+
+    /**
+     * 매니저에게 할당된 예약 상세 조회
+     * @param managerId 매니저ID
+     * @param reservationId 예약ID
+     * @return 매니저에게 할당된 예약 상세 정보를 담은 응답
+     */
+    ManagerReservationRspDTO getManagerReservation(Long managerId, Long reservationId);
+}

--- a/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationServiceImpl.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationServiceImpl.java
@@ -1,0 +1,63 @@
+package com.kernel.reservation.service;
+
+import com.kernel.reservation.repository.ManagerReservationRepository;
+import com.kernel.reservation.service.info.ManagerReservationDetailInfo;
+import com.kernel.reservation.service.info.ManagerReservationSummaryInfo;
+import com.kernel.reservation.service.request.ManagerReservationSearchCondDTO;
+import com.kernel.reservation.service.response.ManagerReservationRspDTO;
+import com.kernel.reservation.service.response.ManagerReservationSummaryRspDTO;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ManagerReservationServiceImpl implements ManagerReservationService {
+
+    private final ManagerReservationRepository managerReservationRepository;
+
+    /**
+     * 매니저에게 할당된 예약 목록 조회 (검색 조건 및 페이징 처리)
+     * @param managerId 매니저ID
+     * @param searchCondDTO 검색조건DTO
+     * @param pageable 페이징
+     * @return 조건에 맞는 예약 정보를 담은 Page 객체
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public Page<ManagerReservationSummaryRspDTO> searchManagerReservationsWithPaging(
+            Long managerId, ManagerReservationSearchCondDTO searchCondDTO, Pageable pageable) {
+        
+        // 조건 및 페이징 포함된 매니저에게 할당된 예약 목록 조회
+        Page<ManagerReservationSummaryInfo> searchedReservationPage = managerReservationRepository.searchManagerReservationsWithPaging(managerId, searchCondDTO, pageable);
+
+        // ManagerReservationSummaryInfo -> ManagerReservationSummaryRspDTO 변환
+        List<ManagerReservationSummaryRspDTO> dtoList = ManagerReservationSummaryRspDTO.fromInfo(searchedReservationPage);
+
+        return new PageImpl<>(dtoList, pageable, searchedReservationPage.getTotalElements());
+    }
+
+    /**
+     * 매니저에게 할당된 예약 상세 조회
+     * @param managerId 매니저ID
+     * @param reservationId 예약ID
+     * @return 매니저 예약 상세 정보 DTO
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public ManagerReservationRspDTO getManagerReservation(Long managerId, Long reservationId) {
+
+        // 매니저에게 할당된 예약 상세 조회
+        ManagerReservationDetailInfo managerDetail = managerReservationRepository.findByManagerIdAndReservationId(managerId, reservationId);
+
+        ManagerReservationRspDTO responseDTO = ManagerReservationRspDTO.fromInfo(managerDetail);
+
+        return responseDTO;
+    }
+}

--- a/reservation/src/main/java/com/kernel/reservation/service/info/ManagerReservationDetailInfo.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/info/ManagerReservationDetailInfo.java
@@ -1,0 +1,34 @@
+package com.kernel.reservation.service.info;
+
+import com.kernel.reservation.domain.enums.ReservationStatus;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ManagerReservationDetailInfo {
+
+    // 예약 상세 정보
+    private Long reservationId;
+    private LocalDate requestDate;  // 예약 요청 일자
+    private LocalTime startTime;
+    private Integer turnaround;     // 예약 소요 시간 (시간 단위)
+    private String serviceName;
+    private ReservationStatus status;
+    private Long customerId;
+    private String extraService;
+    private String memo;
+
+    // 체크인 여부
+    private Long reservationCheckId; // 체크 ID
+    private Timestamp inTime; // 체크인 여부
+    private Long inFileId; // 체크인 첨부파일
+    private Timestamp outTime; // 체크아웃 여부
+    private Long outFileId; // 체크아웃 첨부파일
+
+}

--- a/reservation/src/main/java/com/kernel/reservation/service/info/ManagerReservationSummaryInfo.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/info/ManagerReservationSummaryInfo.java
@@ -1,0 +1,35 @@
+package com.kernel.reservation.service.info;
+
+import com.kernel.reservation.domain.entity.ExtraService;
+import com.kernel.reservation.domain.entity.ServiceCategory;
+import com.kernel.reservation.domain.enums.ReservationStatus;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ManagerReservationSummaryInfo {
+
+    // 예약 요약 정보
+    private Long reservationId;
+    private LocalDate requestDate;  // 예약 요청 날짜
+    private LocalTime startTime;    // 예약 시작 시간
+    private Integer turnaround;     // 예약 소요 시간 (시간 단위)
+    private Long customerId;
+    private String serviceName;     // 서비스명
+    private ReservationStatus status;
+
+    // 체크인 및 체크아웃 정보
+    private Long serviceCheckId; // 체크 ID
+    private Boolean isCheckedIn; // 체크인 여부
+    private Timestamp inTime; // 체크인 일시
+    private Boolean isCheckedOut; // 체크아웃 여부
+    private Timestamp outTime; // 체크아웃 일시
+
+}

--- a/reservation/src/main/java/com/kernel/reservation/service/request/ManagerReservationSearchCondDTO.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/request/ManagerReservationSearchCondDTO.java
@@ -1,0 +1,35 @@
+package com.kernel.reservation.service.request;
+
+import com.kernel.reservation.domain.enums.ReservationStatus;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ManagerReservationSearchCondDTO {
+
+    // 예약 날짜 시작일
+    public LocalDate fromRequestDate;
+
+    // 예약 날짜 종료일
+    public LocalDate toRequestDate;
+
+    // 예약 상태
+    private List<ReservationStatus> reservationStatus;
+
+    // 체크인 여부
+    private Boolean isCheckedIn;
+
+    // 체크아웃 여부
+    private Boolean isCheckedOut;
+
+    // 리뷰 작성 여부
+    private Boolean isReviewed;
+
+    // 고객명
+    public String customerNameKeyword;
+}

--- a/reservation/src/main/java/com/kernel/reservation/service/response/ManagerReservationRspDTO.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/response/ManagerReservationRspDTO.java
@@ -1,0 +1,94 @@
+package com.kernel.reservation.service.response;
+
+import com.kernel.reservation.domain.enums.ReservationStatus;
+
+import com.kernel.reservation.service.info.ManagerReservationDetailInfo;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ManagerReservationRspDTO {
+
+    /* 예약 정보 **************************************/
+    // 예약ID
+    private Long reservationId;
+
+    // 청소 요청 날짜
+    private LocalDate requestDate;
+
+    // 예약시간
+    private LocalTime startTime;
+
+    // 소요시간
+    private Integer turnaround;
+
+    // 서비스명
+    private String serviceName;
+
+    // 상태
+    private ReservationStatus status;
+
+    // 상태명
+    private String statusName;
+
+
+    /* 고객 정보 **************************************/
+    // 고객 ID
+    private Long customerId;
+
+
+    /* 서비스 상세 ************************************/
+    // 추가 서비스
+    private String extraServiceName;
+    // 고객 요청사항
+    private String memo;
+
+
+    /* 체크인/ 체크아웃 ********************************/
+    // 체크ID
+    private Long checkId;
+
+    // 체크인 일시
+    private LocalDateTime inTime;
+
+    // 체크인 첨부파일
+    private Long inFileId;
+
+    // 체크아웃 일시
+    private LocalDateTime outTime;
+
+    // 체크아웃 첨부파일
+    private Long outFileId;
+
+    // ManagerReservationDetailInfo에서 필요한 필드만 포함
+    public static ManagerReservationRspDTO fromInfo(ManagerReservationDetailInfo info) {
+        ManagerReservationRspDTO dto = new ManagerReservationRspDTO();
+        dto.setReservationId(info.getReservationId());
+        dto.setRequestDate(info.getRequestDate());
+        dto.setStartTime(info.getStartTime());
+        dto.setTurnaround(info.getTurnaround());
+        dto.setServiceName(info.getServiceName());
+        dto.setStatus(info.getStatus());
+        dto.setCustomerId(info.getCustomerId());
+        dto.setExtraServiceName(info.getExtraService());
+        dto.setMemo(info.getMemo());
+        dto.setCheckId(info.getReservationCheckId());
+        dto.setInTime(info.getInTime() != null ? info.getInTime().toLocalDateTime() : null);
+        dto.setInFileId(info.getInFileId());
+        dto.setOutTime(info.getOutTime() != null ? info.getOutTime().toLocalDateTime() : null);
+        dto.setOutFileId(info.getOutFileId());
+
+        return dto;
+    }
+
+}

--- a/reservation/src/main/java/com/kernel/reservation/service/response/ManagerReservationSummaryRspDTO.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/response/ManagerReservationSummaryRspDTO.java
@@ -1,0 +1,75 @@
+package com.kernel.reservation.service.response;
+
+import com.kernel.reservation.domain.enums.ReservationStatus;
+
+import java.time.LocalTime;
+
+import com.kernel.reservation.service.info.ManagerReservationSummaryInfo;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ManagerReservationSummaryRspDTO {
+
+    // 예약ID
+    private Long reservationId;
+
+    // 청소 요청 날짜
+    private LocalDate requestDate;
+
+    // 예약시간
+    private LocalTime startTime;
+
+    // 소요시간
+    private Integer turnaround;
+
+    // 고객 ID
+    private Long customerId;
+
+    // 상태
+    private ReservationStatus status;
+
+    // 체크 ID
+    private Long reservationCheckId;
+
+    // 체크인 여부
+    private Boolean isCheckedIn;
+    
+    // 체크인 일시
+    private LocalDateTime inTime;
+
+    // 체크아웃 여부
+    private Boolean isCheckedOut;
+    
+    // 체크아웃 일시
+    private LocalDateTime outTime;
+
+    // ManagerReservationSummaryInfo에서 필요한 필드만 포함
+    public static List<ManagerReservationSummaryRspDTO> fromInfo(Page<ManagerReservationSummaryInfo> info) {
+        return info.getContent().stream()
+                .map(reservation -> ManagerReservationSummaryRspDTO.builder()
+                        .reservationId(reservation.getReservationId())
+                        .requestDate(reservation.getRequestDate())
+                        .startTime(reservation.getStartTime())
+                        .turnaround(reservation.getTurnaround())
+                        .customerId(reservation.getCustomerId())
+                        .status(reservation.getStatus())
+                        .reservationCheckId(reservation.getServiceCheckId())
+                        .isCheckedIn(reservation.getIsCheckedIn())
+                        .inTime(reservation.getInTime() != null ? reservation.getInTime().toLocalDateTime() : null)
+                        .isCheckedOut(reservation.getIsCheckedOut())
+                        .outTime(reservation.getOutTime() != null ? reservation.getOutTime().toLocalDateTime() : null)
+                        .build())
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## ✅ 작업 유형

- [ ] ♻️ 리팩토링 (Refactor)

---

## 🔍 작업 내용

<!-- 어떤 작업을 했는지 구체적으로 적어주세요 (코드, 로직, 예외 처리 등) -->
- manager 예약 조회 쿼리 리펙토링
  - 기존 member 모듈과 evaluation 모듈이 reservation 모듈에 의존하고 있는 구조로 인해, 기존에 member 모듈에서 customer와 review를 조인하여 조회하던 방식을 삭제
  - entity -> tuple -> DTO 방식을 entity -> info -> DTO 방식으로 수정
-  Spring Boot app 실행시 evaluation 모듈에서 발생한 오류 수정
 - JPA 쿼리에서 잘못된 이름 수정

---

## 💬 리뷰요청

<!-- 리뷰어가 참고하면 좋을 내용, 고민한 점 등을 자유롭게 작성해주세요 -->
- 실행 테스트까지 완료해서 동작에는 문제가 없습니다. review와 customer는 의존성을 가져올 수 없어 클라이언트에서 별도의 api로 호출해서 가져오려고 합니다. 다른 방안을 생각해두신 것이 있다면 리뷰 부탁드립니다.

---

## 📎 관련 이슈

<!-- 관련된 이슈 번호가 있다면 연결해주세요 -->
Closes #172 

