### PR TITLE
[Fix] 관리자의 매니저 목록 조회 및 상세 조회 오류 수정

### DIFF
--- a/member/src/main/java/com/kernel/member/common/exception/ManagerNotFoundException.java
+++ b/member/src/main/java/com/kernel/member/common/exception/ManagerNotFoundException.java
@@ -1,0 +1,7 @@
+package com.kernel.member.common.exception;
+
+public class ManagerNotFoundException extends RuntimeException {
+    public ManagerNotFoundException(Long managerId) {
+        super("매니저를 찾을 수 없습니다. ID: " + managerId);
+    }
+}

--- a/member/src/main/java/com/kernel/member/common/exception/MemberExceptionHandler.java
+++ b/member/src/main/java/com/kernel/member/common/exception/MemberExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.kernel.member.common.exception;
+
+import com.kernel.global.service.dto.response.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class MemberExceptionHandler {
+
+    @ExceptionHandler(ManagerNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleManagerNotFoundException(ManagerNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ApiResponse<>(false, ex.getMessage(), null));
+    }
+}

--- a/member/src/main/java/com/kernel/member/service/common/info/AdminManagerDetailInfo.java
+++ b/member/src/main/java/com/kernel/member/service/common/info/AdminManagerDetailInfo.java
@@ -7,29 +7,31 @@ import com.kernel.member.service.response.AvailableTimeRspDTO;
 
 import lombok.*;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class AdminManagerDetailInfo {
 
-    private Long managerId;
+    private Long userId;
     private String userName;
     private String phone;
     private String email;
     private UserStatus status;
-    private String birthDate;
+    private LocalDate birthDate;
     private Gender gender;
     private String roadAddress;
     private String detailAddress;
     private String bio;
-    private Long profileImageId;
+    private Long profileImageFileId;
     private Long fileId; // 첨부파일 ID
     private ContractStatus contractStatus;
     private LocalDateTime contractDate;
-    private Double rating;
+    private BigDecimal averageRating;
     private Integer reservationCount;
     private Integer reviewCount;
     private LocalDateTime terminatedAt;

--- a/member/src/main/java/com/kernel/member/service/common/info/ManagerSummaryInfo.java
+++ b/member/src/main/java/com/kernel/member/service/common/info/ManagerSummaryInfo.java
@@ -1,6 +1,7 @@
 package com.kernel.member.service.common.info;
 
 import com.kernel.global.common.enums.UserStatus;
+import com.kernel.member.common.enums.ContractStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,15 +10,16 @@ import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ManagerSummaryInfo {
-    private Long managerId;
+    private Long userId;
     private String userName;
     private String phone;
     private String email;
     private BigDecimal averageRating;
     private UserStatus userstatus;
+    private ContractStatus contractStatus;
     private Integer reservationCount;
     private Integer reviewCount;
 }

--- a/member/src/main/java/com/kernel/member/service/request/AdminManagerSearchReqDTO.java
+++ b/member/src/main/java/com/kernel/member/service/request/AdminManagerSearchReqDTO.java
@@ -2,6 +2,7 @@ package com.kernel.member.service.request;
 
 import com.kernel.global.common.enums.UserStatus;
 
+import com.kernel.member.common.enums.ContractStatus;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.Getter;
@@ -29,6 +30,9 @@ public class AdminManagerSearchReqDTO {
 
     @Schema(description = "매니저 상태")
     private UserStatus status;
+
+    @Schema(description = "계약 상태")
+    private List<ContractStatus> contractStatus;
 
     @Schema(description = "제외시킬 매니저 상태 목록")
     private List<UserStatus> excludeStatus;

--- a/member/src/main/java/com/kernel/member/service/response/AdminManagerRspDTO.java
+++ b/member/src/main/java/com/kernel/member/service/response/AdminManagerRspDTO.java
@@ -43,9 +43,9 @@ public class AdminManagerRspDTO {
     // AdminManagerDetailInfo -> AdminManagerRspDTO
     public static AdminManagerRspDTO fromInfo(AdminManagerDetailInfo info, List<AvailableTimeRspDTO> availableTimes) {
         return AdminManagerRspDTO.builder()
-                .managerId(info.getManagerId())
+                .managerId(info.getUserId())
                 .userName(info.getUserName())
-                .birthDate(info.getBirthDate() != null ? LocalDate.parse(info.getBirthDate()) : null)
+                .birthDate(info.getBirthDate() != null ? info.getBirthDate() : null)
                 .gender(info.getGender())
                 .email(info.getEmail())
                 .phone(info.getPhone())
@@ -54,9 +54,9 @@ public class AdminManagerRspDTO {
                 .status(info.getStatus())
                 .reservationCount(info.getReservationCount())
                 .reviewCount(info.getReviewCount())
-                .averageRating(info.getRating() != null ? BigDecimal.valueOf(info.getRating()) : null)
+                .averageRating(info.getAverageRating())
                 .bio(info.getBio())
-                .profileImageId(info.getProfileImageId())
+                .profileImageId(info.getProfileImageFileId())
                 .fileId(info.getFileId())
                 .availableTimes(availableTimes)
                 .createdAt(info.getCreatedAt())

--- a/member/src/main/java/com/kernel/member/service/response/AdminManagerSummaryRspDTO.java
+++ b/member/src/main/java/com/kernel/member/service/response/AdminManagerSummaryRspDTO.java
@@ -1,6 +1,7 @@
 package com.kernel.member.service.response;
 
 import com.kernel.global.common.enums.UserStatus;
+import com.kernel.member.common.enums.ContractStatus;
 import com.kernel.member.service.common.info.ManagerSummaryInfo;
 
 import lombok.*;
@@ -20,18 +21,20 @@ public class AdminManagerSummaryRspDTO {
     private String email;
     private BigDecimal averageRating;
     private UserStatus userstatus;
+    private ContractStatus contractStatus;
     private Integer reservationCount;
     private Integer reviewCount;
 
     // AdminManagerSummaryRspDTO ->  AdminManagerSummaryRspDTO 리스트
     public static Page<AdminManagerSummaryRspDTO> toDTOList(Page<ManagerSummaryInfo> managers) {
         return managers.map(manager -> AdminManagerSummaryRspDTO.builder()
-                .managerId(manager.getManagerId())
+                .managerId(manager.getUserId())
                 .userName(manager.getUserName())
                 .phone(manager.getPhone())
                 .email(manager.getEmail())
                 .averageRating(manager.getAverageRating())
                 .userstatus(manager.getUserstatus())
+                .contractStatus(manager.getContractStatus())
                 .reservationCount(manager.getReservationCount())
                 .reviewCount(manager.getReviewCount())
                 .build());


### PR DESCRIPTION
## ✅ 작업 유형

- [x] 🐛 버그 수정 (Bug Fix)

---

## 🔍 작업 내용

<!-- 어떤 작업을 했는지 구체적으로 적어주세요 (코드, 로직, 예외 처리 등) -->
- 매니저 목록 조회시 계약 상태 조회 불가능 했던 점을 info 클래스와 DTO에 반환값을 추가해서 수정
- 매니저 상세조회 시 null 값이 발생하는 문제
  - projections.field를 사용시 필드명 지정이 명확해야하는데 변경된 변수명에 대응하지 않은 점을 수정
  - 쿼리 수행 중 fetchOne을 사용했을 때 4개의 데이터가 발생한다는 문제가 있어서 fetchFirst를 사용하는 것으로 임시 수정
    - 하나의 결과가 나오도록 고유값을 사용해 조회했는데 4개의 데이터가 나오는 원인을 찾아야 함
- 상세 정보 조회에서 데이터를 찾을 수 없을 때 커스텀 예외 처리를 추가해 클라이언트에서 오류 원인을 파악할 수 있도록 수정
---

## 💬 리뷰요청

<!-- 리뷰어가 참고하면 좋을 내용, 고민한 점 등을 자유롭게 작성해주세요 -->
- 쿼리에 문제가 있는 부분이 있는지 검토해주세요.

---

## 📎 관련 이슈

<!-- 관련된 이슈 번호가 있다면 연결해주세요 -->
Closes #233 
