### PR TITLE
[Feature] 매니저의 예약 수락 / 거절 기능 추가

### DIFF
--- a/reservation/src/main/java/com/kernel/reservation/common/enums/ReservationErrorCode.java
+++ b/reservation/src/main/java/com/kernel/reservation/common/enums/ReservationErrorCode.java
@@ -9,7 +9,8 @@ public enum ReservationErrorCode {
 
     INSUFFICIENT_POINTS(400,"RESERVATION-001","포인트가 부족합니다."),
     NO_AVAILABLE_MANAGER(404,"RESERVATION-002","요청하신 일정에 가능한 매니저가 없습니다."),
-    NOT_FOUND_RESERVATION(404,"RESERVATION-003","예약이 존재하지 않습니다.");
+    NOT_FOUND_RESERVATION(404,"RESERVATION-003","예약이 존재하지 않습니다."),
+    NOT_FOUND_RESERVATION_MATCH(404,"RESERVATION-004","예약 정보가 일치하지 않습니다.");
 
     private final int status;
     private final String code;

--- a/reservation/src/main/java/com/kernel/reservation/common/handler/ReservationExceptionHandler.java
+++ b/reservation/src/main/java/com/kernel/reservation/common/handler/ReservationExceptionHandler.java
@@ -33,4 +33,6 @@ public class ReservationExceptionHandler {
     }
 
 
+
+
 }

--- a/reservation/src/main/java/com/kernel/reservation/controller/ManagerReservationController.java
+++ b/reservation/src/main/java/com/kernel/reservation/controller/ManagerReservationController.java
@@ -5,6 +5,7 @@ import com.kernel.global.security.CustomUserDetails;
 import com.kernel.global.service.dto.response.ApiResponse;
 import com.kernel.reservation.service.ManagerReservationService;
 import com.kernel.reservation.service.request.ManagerReservationSearchCondDTO;
+import com.kernel.reservation.service.request.ReservationCancelReqDTO;
 import com.kernel.reservation.service.response.ManagerReservationRspDTO;
 import com.kernel.reservation.service.response.ManagerReservationSummaryRspDTO;
 
@@ -15,11 +16,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Manager Reservation API", description = "매니저 예약 관리 API")
 @RestController
@@ -63,4 +60,39 @@ public class ManagerReservationController {
         ManagerReservationRspDTO responseDTO = reservationService.getManagerReservation(user.getUserId(), reservationId);
         return ResponseEntity.ok(new ApiResponse<>(true, "매니저 예약 상세 조회 성공", responseDTO));
     }
+
+    /**
+     * 매니저가 예약을 수락 API
+     * @param user 매니저
+     * @param reservationId 예약ID
+     */
+    @PostMapping("/{reservation-id}/accept")
+    public ResponseEntity<ApiResponse<Void>> acceptReservation(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable("reservation-id") Long reservationId
+    ) {
+        reservationService.acceptReservation(user.getUserId(), reservationId);
+
+        return ResponseEntity.ok(new ApiResponse<>(true, "예약 수락 성공", null));
+    }
+
+    /**
+     * 매니저가 예약을 거절 API
+     * @param user 매니저
+     * @param reservationId 예약ID
+     * @return 예약 거절 성공 응답
+     */
+    @PostMapping("/{reservation-id}/reject")
+    public ResponseEntity<ApiResponse<Void>> rejectReservation(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable("reservation-id") Long reservationId,
+            @RequestBody(required = true) ReservationCancelReqDTO request
+
+    ) {
+        reservationService.rejectReservation(user.getUserId(), reservationId, request);
+
+        return ResponseEntity.ok(new ApiResponse<>(true, "예약 거절 성공", null));
+    }
+
+
 }

--- a/reservation/src/main/java/com/kernel/reservation/repository/CustomManagerReservationRepositoryImpl.java
+++ b/reservation/src/main/java/com/kernel/reservation/repository/CustomManagerReservationRepositoryImpl.java
@@ -3,10 +3,7 @@ package com.kernel.reservation.repository;
 import com.kernel.global.common.enums.UserRole;
 import com.kernel.global.domain.entity.QUser;
 import com.kernel.member.domain.entity.QUserInfo;
-import com.kernel.reservation.domain.entity.QExtraService;
-import com.kernel.reservation.domain.entity.QReservationMatch;
-import com.kernel.reservation.domain.entity.QReservationSchedule;
-import com.kernel.reservation.domain.entity.QServiceCheckLog;
+import com.kernel.reservation.domain.entity.*;
 import com.kernel.reservation.service.info.ManagerReservationDetailInfo;
 import com.kernel.reservation.service.info.ManagerReservationSummaryInfo;
 import com.kernel.reservation.service.request.ManagerReservationSearchCondDTO;
@@ -41,6 +38,7 @@ public class CustomManagerReservationRepositoryImpl implements CustomManagerRese
     private final QReservationSchedule reservationSchedule = QReservationSchedule.reservationSchedule;
     private final QServiceCheckLog serviceCheckLog = QServiceCheckLog.serviceCheckLog;
     private final QReservationMatch reservationMatch = QReservationMatch.reservationMatch;
+    private final QReservationCancel reservationCancel = QReservationCancel.reservationCancel;
     private final QServiceCategory serviceCategory = QServiceCategory.serviceCategory;
     private final QExtraService extraService = QExtraService.extraService;
 
@@ -162,6 +160,9 @@ public class CustomManagerReservationRepositoryImpl implements CustomManagerRese
                 reservation.user.userId,
                 //extraServiceNameExpr,
                 reservation.memo,
+                reservationCancel.cancelDate,
+                reservationCancel.canceledById,
+                reservationCancel.cancelReason,
                 serviceCheckLog.reservation,
                 serviceCheckLog.inTime,
                 serviceCheckLog.inFileId,
@@ -176,6 +177,7 @@ public class CustomManagerReservationRepositoryImpl implements CustomManagerRese
             .leftJoin(serviceCheckLog).on(serviceCheckLog.reservation.eq(reservation))
             .leftJoin(reservationMatch).on(reservationMatch.reservation.eq(reservation))
             .leftJoin(reservation.serviceCategory, serviceCategory)
+            .leftJoin(reservationCancel).on(reservationCancel.reservation.eq(reservation))
             .leftJoin(user).on(reservation.user.eq(user))
             .leftJoin(userInfo).on(userInfo.user.eq(user))
             .where(

--- a/reservation/src/main/java/com/kernel/reservation/repository/ReservationMatchRepository.java
+++ b/reservation/src/main/java/com/kernel/reservation/repository/ReservationMatchRepository.java
@@ -1,0 +1,9 @@
+package com.kernel.reservation.repository;
+
+import com.kernel.reservation.domain.entity.ReservationMatch;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReservationMatchRepository extends JpaRepository<ReservationMatch, Long> {
+
+    // Define any additional query methods if needed
+}

--- a/reservation/src/main/java/com/kernel/reservation/repository/ReservationMatchRepository.java
+++ b/reservation/src/main/java/com/kernel/reservation/repository/ReservationMatchRepository.java
@@ -3,7 +3,9 @@ package com.kernel.reservation.repository;
 import com.kernel.reservation.domain.entity.ReservationMatch;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ReservationMatchRepository extends JpaRepository<ReservationMatch, Long> {
 
-    // Define any additional query methods if needed
+    Optional<ReservationMatch> findByReservation_ReservationIdAndManager_UserId(Long reservationId, Long managerId);
 }

--- a/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationService.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationService.java
@@ -2,6 +2,7 @@ package com.kernel.reservation.service;
 
 
 import com.kernel.reservation.service.request.ManagerReservationSearchCondDTO;
+import com.kernel.reservation.service.request.ReservationCancelReqDTO;
 import com.kernel.reservation.service.response.ManagerReservationRspDTO;
 import com.kernel.reservation.service.response.ManagerReservationSummaryRspDTO;
 import org.springframework.data.domain.Page;
@@ -25,4 +26,18 @@ public interface ManagerReservationService {
      * @return 매니저에게 할당된 예약 상세 정보를 담은 응답
      */
     ManagerReservationRspDTO getManagerReservation(Long managerId, Long reservationId);
+
+    /**
+     * 매니저가 예약을 수락
+     * @param managerId 매니저ID
+     * @param reservationId 예약ID
+     */
+    void acceptReservation(Long managerId, Long reservationId);
+
+    /**
+     * 매니저가 예약을 거절
+     * @param managerId 매니저ID
+     * @param reservationId 예약ID
+     */
+    void rejectReservation(Long managerId, Long reservationId, ReservationCancelReqDTO request);
 }

--- a/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationServiceImpl.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationServiceImpl.java
@@ -4,6 +4,8 @@ import com.kernel.global.common.enums.UserRole;
 import com.kernel.global.common.enums.UserStatus;
 import com.kernel.global.domain.entity.User;
 import com.kernel.global.repository.UserRepository;
+import com.kernel.reservation.common.enums.ReservationErrorCode;
+import com.kernel.reservation.common.exception.ReservationException;
 import com.kernel.reservation.domain.entity.ReservationCancel;
 import com.kernel.reservation.domain.entity.ReservationMatch;
 import com.kernel.reservation.repository.ManagerReservationRepository;
@@ -94,11 +96,11 @@ public class ManagerReservationServiceImpl implements ManagerReservationService 
     public void acceptReservation(Long managerId, Long reservationId) {
         // 1. 매니저에게 할당된 예약 조회
         Reservation requestedReservation = managerReservationRepository.findById(reservationId)
-                .orElseThrow(() -> new IllegalArgumentException("예약이 존재하지 않습니다."));
+                .orElseThrow(() -> new ReservationException(ReservationErrorCode.NOT_FOUND_RESERVATION));
 
         // 2. 매니저와 예약 매칭 정보 조회
         ReservationMatch reservationMatch = reservationMatchRepository.findByReservation_ReservationIdAndManager_UserId(reservationId, managerId)
-                .orElseThrow(() -> new IllegalArgumentException("매니저와 예약 매칭 정보가 존재하지 않습니다."));
+                .orElseThrow(() -> new ReservationException(ReservationErrorCode.NOT_FOUND_RESERVATION_MATCH));
 
         // 3. 매니저 수락 처리
         String reason = "매니저가 예약을 수락하였습니다.";
@@ -119,11 +121,11 @@ public class ManagerReservationServiceImpl implements ManagerReservationService 
     public void rejectReservation(Long managerId, Long reservationId, ReservationCancelReqDTO request) {
         // 1. 매니저에게 할당된 예약 조회
         Reservation requestedReservation = managerReservationRepository.findById(reservationId)
-                .orElseThrow(() -> new IllegalArgumentException("예약이 존재하지 않습니다."));
+                .orElseThrow(() -> new ReservationException(ReservationErrorCode.NOT_FOUND_RESERVATION));
 
         // 2. 매니저와 예약 매칭 정보 조회
         ReservationMatch reservationMatch = reservationMatchRepository.findByReservation_ReservationIdAndManager_UserId(reservationId, managerId)
-                .orElseThrow(() -> new IllegalArgumentException("매니저와 예약 매칭 정보가 존재하지 않습니다."));
+                .orElseThrow(() -> new ReservationException(ReservationErrorCode.NOT_FOUND_RESERVATION_MATCH));
 
         // 3. 매니저 거절 처리
         requestedReservation.changeStatus(request.getCancelReason(), ReservationStatus.CANCELED);

--- a/reservation/src/main/java/com/kernel/reservation/service/info/ManagerReservationDetailInfo.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/info/ManagerReservationDetailInfo.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import java.sql.Timestamp;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 @Getter
@@ -24,6 +25,9 @@ public class ManagerReservationDetailInfo {
     private Long customerId;
     private String extraService;
     private String memo;
+    private LocalDateTime cancelDate;
+    private Long canceledById;
+    private String cancelReason;
     private Long reservationCheckId;
     private Timestamp inTime;
     private Long inFileId;
@@ -32,5 +36,6 @@ public class ManagerReservationDetailInfo {
     private String roadAddress;
     private String detailAddress;
     private String userName;
+
 
 }

--- a/reservation/src/main/java/com/kernel/reservation/service/response/ManagerReservationRspDTO.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/response/ManagerReservationRspDTO.java
@@ -81,8 +81,6 @@ public class ManagerReservationRspDTO {
     @Schema(description = "예약 취소자 유형", example = "MANAGER", required = false)
     private UserRole canceledByRole;
 
-
-
     @Schema(description = "ManagerReservationDetailInfo에서 필요한 필드만 포함하여 DTO로 변환")
     public static ManagerReservationRspDTO fromInfo(ManagerReservationDetailInfo info, User canceledBy) {
         return ManagerReservationRspDTO.builder()
@@ -93,18 +91,18 @@ public class ManagerReservationRspDTO {
                 .serviceName(info.getServiceName())
                 .status(info.getStatus())
                 .customerId(info.getCustomerId())
-                .extraServiceName(info.getExtraService())
-                .memo(info.getMemo())
-                .checkId(info.getReservationCheckId())
-                .inTime(info.getInTime() != null ? info.getInTime().toLocalDateTime() : null)
-                .inFileId(info.getInFileId())
-                .outTime(info.getOutTime() != null ? info.getOutTime().toLocalDateTime() : null)
-                .outFileId(info.getOutFileId())
                 .roadAddress(info.getRoadAddress())
                 .detailAddress(info.getDetailAddress())
                 .userName(info.getUserName())
-                .cancelDate(info.getCancelDate())
-                .cancelReason(info.getCancelReason())
+                .extraServiceName(info.getExtraService() != null ? info.getExtraService() : null)
+                .memo(info.getMemo() != null ? info.getMemo() : null)
+                .checkId(info.getReservationCheckId() != null ? info.getReservationCheckId() : null)
+                .inTime(info.getInTime() != null ? info.getInTime().toLocalDateTime() : null)
+                .inFileId(info.getInFileId() != null ? info.getInFileId() : null)
+                .outTime(info.getOutTime() != null ? info.getOutTime().toLocalDateTime() : null)
+                .outFileId(info.getOutFileId() != null ? info.getOutFileId() : null)
+                .cancelDate(info.getCancelDate() != null ? info.getCancelDate() : null)
+                .cancelReason(info.getCancelReason() != null ? info.getCancelReason() : null)
                 .canceledByName(canceledBy != null ? canceledBy.getUserName() : null)
                 .canceledByRole(canceledBy != null ? canceledBy.getRole() : null)
                 .build();

--- a/reservation/src/main/java/com/kernel/reservation/service/response/ManagerReservationRspDTO.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/response/ManagerReservationRspDTO.java
@@ -1,5 +1,7 @@
 package com.kernel.reservation.service.response;
 
+import com.kernel.global.common.enums.UserRole;
+import com.kernel.global.domain.entity.User;
 import com.kernel.reservation.service.info.ManagerReservationDetailInfo;
 import com.kernel.sharedDomain.common.enums.ReservationStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -67,8 +69,22 @@ public class ManagerReservationRspDTO {
     @Schema(description = "고객 이름", example = "홍길동", required = true)
     private String userName;
 
+    @Schema(description = "예약 취소 일시", example = "2023-01-01T15:00:00", required = false)
+    private LocalDateTime cancelDate;
+
+    @Schema(description = "예약 취소 사유", example = "고객 요청으로 예약 취소", required = false)
+    private String cancelReason;
+
+    @Schema(description = "예약 취소자 이름" , example = "김매니저", required = false)
+    private String canceledByName;
+
+    @Schema(description = "예약 취소자 유형", example = "MANAGER", required = false)
+    private UserRole canceledByRole;
+
+
+
     @Schema(description = "ManagerReservationDetailInfo에서 필요한 필드만 포함하여 DTO로 변환")
-    public static ManagerReservationRspDTO fromInfo(ManagerReservationDetailInfo info) {
+    public static ManagerReservationRspDTO fromInfo(ManagerReservationDetailInfo info, User canceledBy) {
         return ManagerReservationRspDTO.builder()
                 .reservationId(info.getReservationId())
                 .requestDate(info.getRequestDate())
@@ -87,6 +103,10 @@ public class ManagerReservationRspDTO {
                 .roadAddress(info.getRoadAddress())
                 .detailAddress(info.getDetailAddress())
                 .userName(info.getUserName())
+                .cancelDate(info.getCancelDate())
+                .cancelReason(info.getCancelReason())
+                .canceledByName(canceledBy != null ? canceledBy.getUserName() : null)
+                .canceledByRole(canceledBy != null ? canceledBy.getRole() : null)
                 .build();
     }
 

--- a/shared-domain/src/main/java/com/kernel/sharedDomain/domain/entity/Reservation.java
+++ b/shared-domain/src/main/java/com/kernel/sharedDomain/domain/entity/Reservation.java
@@ -58,7 +58,10 @@ public class Reservation extends BaseEntity {
     public void changeStatus(String reason, ReservationStatus reservationStatus) {
         this.status = reservationStatus;
         // TODO: 상태 변경 사유를 매개변수로 받는데 어떻게 처리할지 결정해야 함
+    }
 
+    public void managerAccept() {
+        this.status = ReservationStatus.CONFIRMED;
     }
 
 

--- a/shared-domain/src/main/java/com/kernel/sharedDomain/domain/entity/Reservation.java
+++ b/shared-domain/src/main/java/com/kernel/sharedDomain/domain/entity/Reservation.java
@@ -55,7 +55,11 @@ public class Reservation extends BaseEntity {
     }
 
     // 예약 상태 변경
-    public void changeStatus(String cancelReason, ReservationStatus reservationStatus) {
+    public void changeStatus(String reason, ReservationStatus reservationStatus) {
         this.status = reservationStatus;
+        // TODO: 상태 변경 사유를 매개변수로 받는데 어떻게 처리할지 결정해야 함
+
     }
+
+
 }


### PR DESCRIPTION
## ✅ 작업 유형

- [x] ✨ 기능 추가 (Feature)

---

## 🔍 작업 내용

<!-- 어떤 작업을 했는지 구체적으로 적어주세요 (코드, 로직, 예외 처리 등) -->
- 매니저 예약 수락 / 거절 api 추가
- 매니저 예약 수락
  - reservation entity의 상태를 "CONFIRMED"로 수정
  - reservationMatch entity의 상태를 "MATCHED"로 수정
- 매니저 예약 거절
  - reservation entity의 상태를 "CANCELED"로 수정
  - reservationMatch entity의 상태를 "REJECTED"로 수정
  - reservationCancel 테이블에 이력 추가

---

## 💬 리뷰요청

<!-- 리뷰어가 참고하면 좋을 내용, 고민한 점 등을 자유롭게 작성해주세요 -->
- 예약 수락 / 거절에 대한 api와 service 로직을 만들어 동작을 분리를 했습니다. 코드 중복이 있지만 수락과 거절의 로직이 달라서 구분했습니다. Service를 분리한 것에 대해서 리뷰부탁드립니다.
- 예약 수락시 예약 상태, 예약 매칭 상태를 변경했고 거절시 수락 로직에 예약 취소 테이블에 이력을 추가하는 로직을 추가했습니다. 이 방법이 적절한지 리뷰해주세요.
- 클라이언트에서 기능 테스트를 수행했을 때 정상 동작 확인했습니다.

---

## 📎 관련 이슈

<!-- 관련된 이슈 번호가 있다면 연결해주세요 -->
Closes #171 
