### PR TITLE
[Refactor] 매니저 체크인/체크아웃 기능 리펙토링

### DIFF
--- a/global/src/main/java/com/kernel/global/config/SecurityConfig.java
+++ b/global/src/main/java/com/kernel/global/config/SecurityConfig.java
@@ -85,6 +85,8 @@ public class SecurityConfig {
                     .accessDeniedHandler(jwtAccessDeniedHandler)
             )
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            // JWT 인증 필터: 요청이 authorizeHttpRequests()의 인증/권한 체크 전에 실행되어 SecurityContextHolder에 인증 객체를 설정
+            .addFilterBefore(new JwtFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
             .addFilterBefore(new CustomLogoutFilter(jwtTokenProvider, refreshRepository), LogoutFilter.class)
             .logout(logout -> logout
                     .logoutUrl("/api/logout")

--- a/global/src/main/java/com/kernel/global/controller/FileUploadController.java
+++ b/global/src/main/java/com/kernel/global/controller/FileUploadController.java
@@ -33,10 +33,10 @@ public class FileUploadController {
     }
 
     @PostMapping("/presigned-urls")
-    public ResponseEntity<ApiResponse<List<PresignedUrlRspDTO>>> generatePresignedUrls(
+    public ResponseEntity<ApiResponse<PresignedUrlRspDTO>> generatePresignedUrls(
             @RequestBody @Valid PresignedUrlReqDTO request
     ) {
-        List<PresignedUrlRspDTO> response = fileUploadService.generatePresignedUrls(request);
+        PresignedUrlRspDTO response = fileUploadService.generatePresignedUrls(request);
         return ResponseEntity.ok(new ApiResponse<>(true, "프리사인드 URL 생성 성공", response));
     }
 

--- a/global/src/main/java/com/kernel/global/domain/entity/File.java
+++ b/global/src/main/java/com/kernel/global/domain/entity/File.java
@@ -24,7 +24,7 @@ public class File extends BaseEntity {
     private Long fileId;
 
     // 파일의 경로를 JSON 배열 형태로 저장
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "LONGTEXT")    // 파일 경로가 VARCHAR(255)보다 길 수 있으므로 LONGTEXT 사용
     private String filePathsJson;
 
     // 게시물의 실제 게시 상태

--- a/global/src/main/java/com/kernel/global/service/FileUploadService.java
+++ b/global/src/main/java/com/kernel/global/service/FileUploadService.java
@@ -14,7 +14,7 @@ public interface FileUploadService {
 
     FileGetRspDTO getFileList(Long fileId);
 
-    List<PresignedUrlRspDTO> generatePresignedUrls(PresignedUrlReqDTO request);
+    PresignedUrlRspDTO generatePresignedUrls(PresignedUrlReqDTO request);
 
     FileUploadRspDTO uploadFiles(FileUploadReqDTO request);
 

--- a/global/src/main/java/com/kernel/global/service/FileUploadServiceImpl.java
+++ b/global/src/main/java/com/kernel/global/service/FileUploadServiceImpl.java
@@ -57,7 +57,7 @@ public class FileUploadServiceImpl implements FileUploadService {
      * @return Presigned URL 응답 DTO
      */
     @Override
-    public List<PresignedUrlRspDTO> generatePresignedUrls(PresignedUrlReqDTO request) {
+    public PresignedUrlRspDTO generatePresignedUrls(PresignedUrlReqDTO request) {
         List<PresignedPutObjectRequest> presignedUrls = new ArrayList<>();
 
         for (String file : request.getFiles()) {
@@ -96,6 +96,8 @@ public class FileUploadServiceImpl implements FileUploadService {
         } catch (JsonProcessingException e) {
             throw new RuntimeException("파일 경로를 JSON으로 변환하는 중 오류가 발생했습니다");
         }
+
+        System.out.println("파일 경로 JSON: " + filePathsJson);
 
         File uploadedFiles = File.builder()
                 .filePathsJson(filePathsJson)

--- a/global/src/main/java/com/kernel/global/service/FileUploadServiceImpl.java
+++ b/global/src/main/java/com/kernel/global/service/FileUploadServiceImpl.java
@@ -97,8 +97,6 @@ public class FileUploadServiceImpl implements FileUploadService {
             throw new RuntimeException("파일 경로를 JSON으로 변환하는 중 오류가 발생했습니다");
         }
 
-        System.out.println("파일 경로 JSON: " + filePathsJson);
-
         File uploadedFiles = File.builder()
                 .filePathsJson(filePathsJson)
                 .postStatus(PostStatus.REGISTERED)

--- a/global/src/main/java/com/kernel/global/service/dto/response/PresignedUrlRspDTO.java
+++ b/global/src/main/java/com/kernel/global/service/dto/response/PresignedUrlRspDTO.java
@@ -9,18 +9,20 @@ import java.util.List;
 
 @Getter
 @Builder
-@Schema(description = "프리사인 URL 응답 DTO")
+@Schema(description = "Presigned URL 응답 DTO")
 public class PresignedUrlRspDTO {
 
-    @Schema(description = "프리사인 URL 목록", example = "[\"https://example.com/file1\", \"https://example.com/file2\"]", required = true)
+    @Schema(description = "Presigned URL 목록", example = "[\"https://example.com/file1\", \"https://example.com/file2\"]", required = true)
     private List<String> preSignedUrls;
 
     // PresignedPutObjectRequest to PresignedUrlRspDTO 변환 메소드
-    public static List<PresignedUrlRspDTO> fromPresignedUrls(List<PresignedPutObjectRequest> preSignedUrls) {
-        return preSignedUrls.stream()
-                .map(url -> PresignedUrlRspDTO.builder()
-                        .preSignedUrls(List.of(url.url().toString()))
-                        .build())
-                .toList();
+    public static PresignedUrlRspDTO fromPresignedUrls(List<PresignedPutObjectRequest> preSignedUrls) {
+        return PresignedUrlRspDTO.builder()
+                .preSignedUrls(preSignedUrls.stream()
+                        .map(PresignedPutObjectRequest::url)
+                        .map(Object::toString)
+                        .toList())
+                .build();
+
     }
 }

--- a/reservation/src/main/java/com/kernel/reservation/common/enums/ServiceCheckLogErrorCode.java
+++ b/reservation/src/main/java/com/kernel/reservation/common/enums/ServiceCheckLogErrorCode.java
@@ -14,7 +14,8 @@ public enum ServiceCheckLogErrorCode {
     CHECK_IN_FILE_NOT_FOUND(404, "SERVICE-CHECK-LOG-5", "체크인 첨부파일을 찾을 수 없습니다."),
     CHECK_OUT_FILE_NOT_FOUND(404, "SERVICE-CHECK-LOG-6", "체크아웃 첨부파일을 찾을 수 없습니다."),
     CHECK_IN_FILE_UPLOAD_FAILED(500, "SERVICE-CHECK-LOG-7", "체크인 첨부파일 업로드에 실패했습니다."),
-    CHECK_OUT_FILE_UPLOAD_FAILED(500, "SERVICE-CHECK-LOG-8", "체크아웃 첨부파일 업로드에 실패했습니다.");
+    CHECK_OUT_FILE_UPLOAD_FAILED(500, "SERVICE-CHECK-LOG-8", "체크아웃 첨부파일 업로드에 실패했습니다."),
+    CHECK_IN_NOT_ALLOWED(400, "SERVICE-CHECK-LOG-9", "체크아웃을 하지 않은 예약이 존재합니다.");
 
     private final int status;
     private final String code;

--- a/reservation/src/main/java/com/kernel/reservation/common/enums/ServiceCheckLogErrorCode.java
+++ b/reservation/src/main/java/com/kernel/reservation/common/enums/ServiceCheckLogErrorCode.java
@@ -1,0 +1,22 @@
+package com.kernel.reservation.common.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ServiceCheckLogErrorCode {
+
+    CHECK_IN_ALREADY_EXISTS(400, "SERVICE-CHECK-LOG-1", "체크인 정보가 이미 존재합니다."),
+    CHECK_OUT_ALREADY_EXISTS(400, "SERVICE-CHECK-LOG-2", "체크아웃 정보가 이미 존재합니다."),
+    CHECK_IN_NOT_FOUND(404, "SERVICE-CHECK-LOG-3", "체크인 정보를 찾을 수 없습니다."),
+    CHECK_OUT_NOT_FOUND(404, "SERVICE-CHECK-LOG-4", "체크아웃 정보를 찾을 수 없습니다."),
+    CHECK_IN_FILE_NOT_FOUND(404, "SERVICE-CHECK-LOG-5", "체크인 첨부파일을 찾을 수 없습니다."),
+    CHECK_OUT_FILE_NOT_FOUND(404, "SERVICE-CHECK-LOG-6", "체크아웃 첨부파일을 찾을 수 없습니다."),
+    CHECK_IN_FILE_UPLOAD_FAILED(500, "SERVICE-CHECK-LOG-7", "체크인 첨부파일 업로드에 실패했습니다."),
+    CHECK_OUT_FILE_UPLOAD_FAILED(500, "SERVICE-CHECK-LOG-8", "체크아웃 첨부파일 업로드에 실패했습니다.");
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/reservation/src/main/java/com/kernel/reservation/common/enums/ServiceCheckLogErrorCode.java
+++ b/reservation/src/main/java/com/kernel/reservation/common/enums/ServiceCheckLogErrorCode.java
@@ -7,8 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ServiceCheckLogErrorCode {
 
-    CHECK_IN_ALREADY_EXISTS(400, "SERVICE-CHECK-LOG-1", "체크인 정보가 이미 존재합니다."),
-    CHECK_OUT_ALREADY_EXISTS(400, "SERVICE-CHECK-LOG-2", "체크아웃 정보가 이미 존재합니다."),
+    CHECK_IN_ALREADY_EXISTS(409, "SERVICE-CHECK-LOG-1", "체크인 정보가 이미 존재합니다."),
+    CHECK_OUT_ALREADY_EXISTS(409, "SERVICE-CHECK-LOG-2", "체크아웃 정보가 이미 존재합니다."),
     CHECK_IN_NOT_FOUND(404, "SERVICE-CHECK-LOG-3", "체크인 정보를 찾을 수 없습니다."),
     CHECK_OUT_NOT_FOUND(404, "SERVICE-CHECK-LOG-4", "체크아웃 정보를 찾을 수 없습니다."),
     CHECK_IN_FILE_NOT_FOUND(404, "SERVICE-CHECK-LOG-5", "체크인 첨부파일을 찾을 수 없습니다."),

--- a/reservation/src/main/java/com/kernel/reservation/common/exception/ServiceCheckLogException.java
+++ b/reservation/src/main/java/com/kernel/reservation/common/exception/ServiceCheckLogException.java
@@ -1,0 +1,15 @@
+package com.kernel.reservation.common.exception;
+
+import com.kernel.reservation.common.enums.ServiceCheckLogErrorCode;
+import lombok.Getter;
+
+@Getter
+public class ServiceCheckLogException extends RuntimeException {
+
+    private final ServiceCheckLogErrorCode errorCode;
+
+    public ServiceCheckLogException(ServiceCheckLogErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/reservation/src/main/java/com/kernel/reservation/common/handler/ServiceCheckLogExceptionHandler.java
+++ b/reservation/src/main/java/com/kernel/reservation/common/handler/ServiceCheckLogExceptionHandler.java
@@ -1,0 +1,22 @@
+package com.kernel.reservation.common.handler;
+
+import com.kernel.global.service.dto.response.ApiResponse;
+import com.kernel.reservation.common.exception.ServiceCheckLogException;
+import com.kernel.reservation.service.response.common.ServiceCheckLogErrorRspDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class ServiceCheckLogExceptionHandler {
+
+    @ExceptionHandler(ServiceCheckLogException.class)
+    public ResponseEntity<ServiceCheckLogErrorRspDTO> handleServiceCheckLogException(ServiceCheckLogException e) {
+        log.error("ServiceCheckLogException error: {}", e.getMessage());
+
+        return ResponseEntity.status(e.getErrorCode().getStatus()).body(ServiceCheckLogErrorRspDTO.createErrorResponse(e));
+    }
+
+}

--- a/reservation/src/main/java/com/kernel/reservation/controller/ManagerReservationController.java
+++ b/reservation/src/main/java/com/kernel/reservation/controller/ManagerReservationController.java
@@ -6,10 +6,15 @@ import com.kernel.global.service.dto.response.ApiResponse;
 import com.kernel.reservation.service.ManagerReservationService;
 import com.kernel.reservation.service.request.ManagerReservationSearchCondDTO;
 import com.kernel.reservation.service.request.ReservationCancelReqDTO;
+import com.kernel.reservation.service.request.ServiceCheckInReqDTO;
+import com.kernel.reservation.service.request.ServiceCheckOutReqDTO;
 import com.kernel.reservation.service.response.ManagerReservationRspDTO;
 import com.kernel.reservation.service.response.ManagerReservationSummaryRspDTO;
 
+import com.kernel.reservation.service.response.ServiceCheckInRspDTO;
+import com.kernel.reservation.service.response.ServiceCheckOutRspDTO;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -92,6 +97,41 @@ public class ManagerReservationController {
         reservationService.rejectReservation(user.getUserId(), reservationId, request);
 
         return ResponseEntity.ok(new ApiResponse<>(true, "예약 거절 성공", null));
+    }
+
+    /**
+     * 체크인 API
+     * @param manager 매니저
+     * @param reservationId 예약ID
+     * @param request 체크인 요청 정보
+     * @return 체크인 정보를 담은 응답
+     */
+    @PostMapping("/{reservation-id}/check-in")
+    public ResponseEntity<ApiResponse<ServiceCheckInRspDTO>> checkIn(
+            @AuthenticationPrincipal CustomUserDetails manager,
+            @PathVariable("reservation-id") Long reservationId,
+            @Valid @RequestBody ServiceCheckInReqDTO request
+    ) {
+
+        ServiceCheckInRspDTO responseDTO = reservationService.checkIn(manager.getUserId(), reservationId, request);
+        return ResponseEntity.ok(new ApiResponse<>(true, "체크인 성공", responseDTO));
+    }
+
+    /**
+     * 체크아웃 API
+     * @param reservationId 예약ID
+     * @param request 체크아웃요청DTO
+     * @return 체크아웃 정보를 담은 응답
+     */
+    @PatchMapping("/{reservation-id}/check-out")
+    public ResponseEntity<ApiResponse<ServiceCheckOutRspDTO>> checkOut(
+            @AuthenticationPrincipal CustomUserDetails manager,
+            @PathVariable("reservation-id") Long reservationId,
+            @Valid @RequestBody ServiceCheckOutReqDTO request
+    ) {
+
+        ServiceCheckOutRspDTO responseDTO = reservationService.checkOut(manager.getUserId(), reservationId, request);
+        return ResponseEntity.ok(new ApiResponse<>(true, "체크아웃 성공", responseDTO));
     }
 
 

--- a/reservation/src/main/java/com/kernel/reservation/domain/entity/ServiceCheckLog.java
+++ b/reservation/src/main/java/com/kernel/reservation/domain/entity/ServiceCheckLog.java
@@ -8,11 +8,13 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import java.sql.Timestamp;
 
 @Entity
-@Table(name = "cleaning_log")
+@Table(name = "service_check_log")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -38,15 +40,27 @@ public class ServiceCheckLog extends BaseEntity {
     private Long inFileId;
 
     // 체크아웃 시간
-    @Column(nullable = false)
+    @Column(nullable = true)
     private Timestamp outTime;
 
     // 체크아웃 파일 ID
-    @Column(nullable = false)
+    @Column(nullable = true)
     private Long outFileId;
 
     @PreRemove
     private void preventRemove() {
         throw new UnsupportedOperationException("예약 관련 정보는 삭제할 수 없습니다.");
+    }
+
+    // 체크인
+    public void checkIn(Long inFileId) {
+        this.inTime = new Timestamp(System.currentTimeMillis());
+        this.inFileId = inFileId;
+    }
+
+    // 체크아웃
+    public void checkOut(Long outFileId) {
+        this.outTime = new Timestamp(System.currentTimeMillis());
+        this.outFileId = outFileId;
     }
 }

--- a/reservation/src/main/java/com/kernel/reservation/domain/entity/ServiceCheckLog.java
+++ b/reservation/src/main/java/com/kernel/reservation/domain/entity/ServiceCheckLog.java
@@ -8,8 +8,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
 import java.sql.Timestamp;
 

--- a/reservation/src/main/java/com/kernel/reservation/repository/CustomManagerReservationRepositoryImpl.java
+++ b/reservation/src/main/java/com/kernel/reservation/repository/CustomManagerReservationRepositoryImpl.java
@@ -163,7 +163,7 @@ public class CustomManagerReservationRepositoryImpl implements CustomManagerRese
                 reservationCancel.cancelDate,
                 reservationCancel.canceledById,
                 reservationCancel.cancelReason,
-                serviceCheckLog.reservation,
+                serviceCheckLog.reservation.reservationId.as("reservationCheckId"),
                 serviceCheckLog.inTime,
                 serviceCheckLog.inFileId,
                 serviceCheckLog.outTime,

--- a/reservation/src/main/java/com/kernel/reservation/repository/ServiceCheckLogRepository.java
+++ b/reservation/src/main/java/com/kernel/reservation/repository/ServiceCheckLogRepository.java
@@ -2,6 +2,7 @@ package com.kernel.reservation.repository;
 
 import com.kernel.reservation.domain.entity.ServiceCheckLog;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -14,4 +15,12 @@ public interface ServiceCheckLogRepository extends JpaRepository<ServiceCheckLog
 
     // 예약ID로 조회
     Optional<ServiceCheckLog> findByReservation_ReservationId(Long reservationId);
+
+    // 매니저의 userId를 기준으로 체크아웃되지 않은 체크인 로그 조회
+    @Query("SELECT CASE WHEN COUNT(s) > 0 THEN TRUE ELSE FALSE END " +
+            "FROM Reservation r " +
+            "JOIN ServiceCheckLog s ON r = s.reservation " +
+            "JOIN ReservationMatch rm ON r = rm.reservation " +
+            "WHERE rm.manager.userId = :managerId AND s.inTime IS NOT NULL AND s.outTime IS NULL")
+    Boolean existsByManagerUserIdAndInTimeIsNotNullAndOutTimeIsNull(Long managerId);
 }

--- a/reservation/src/main/java/com/kernel/reservation/repository/ServiceCheckLogRepository.java
+++ b/reservation/src/main/java/com/kernel/reservation/repository/ServiceCheckLogRepository.java
@@ -4,6 +4,8 @@ import com.kernel.reservation.domain.entity.ServiceCheckLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ServiceCheckLogRepository extends JpaRepository<ServiceCheckLog, Long> {
 
@@ -11,5 +13,5 @@ public interface ServiceCheckLogRepository extends JpaRepository<ServiceCheckLog
     Boolean existsByReservation_ReservationId(Long reservationId);
 
     // 예약ID로 조회
-    ServiceCheckLog findByReservation_ReservationId(Long reservationId);
+    Optional<ServiceCheckLog> findByReservation_ReservationId(Long reservationId);
 }

--- a/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationService.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationService.java
@@ -1,8 +1,12 @@
 package com.kernel.reservation.service;
 
 
+import com.kernel.reservation.service.request.ServiceCheckInReqDTO;
+import com.kernel.reservation.service.request.ServiceCheckOutReqDTO;
 import com.kernel.reservation.service.request.ManagerReservationSearchCondDTO;
 import com.kernel.reservation.service.request.ReservationCancelReqDTO;
+import com.kernel.reservation.service.response.ServiceCheckInRspDTO;
+import com.kernel.reservation.service.response.ServiceCheckOutRspDTO;
 import com.kernel.reservation.service.response.ManagerReservationRspDTO;
 import com.kernel.reservation.service.response.ManagerReservationSummaryRspDTO;
 import org.springframework.data.domain.Page;
@@ -40,4 +44,23 @@ public interface ManagerReservationService {
      * @param reservationId 예약ID
      */
     void rejectReservation(Long managerId, Long reservationId, ReservationCancelReqDTO request);
+
+    /**
+     * 체크인
+     * @param managerId
+     * @param reservationId
+     * @param serviceCheckInReqDTO
+     * @return 체크인 정보를 담은 응답
+     */
+    public ServiceCheckInRspDTO checkIn(Long managerId, Long reservationId, ServiceCheckInReqDTO serviceCheckInReqDTO);
+
+    /**
+     * 체크아웃
+     * @param managerId
+     * @param reservationId
+     * @param serviceCheckOutReqDTO
+     * @return 체크아웃 정보를 담은 응답
+     */
+    public ServiceCheckOutRspDTO checkOut(Long managerId, Long reservationId, ServiceCheckOutReqDTO serviceCheckOutReqDTO);
 }
+

--- a/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationServiceImpl.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationServiceImpl.java
@@ -2,23 +2,30 @@ package com.kernel.reservation.service;
 
 import com.kernel.global.common.enums.ErrorCode;
 import com.kernel.global.common.enums.UserRole;
-import com.kernel.global.common.enums.UserStatus;
 import com.kernel.global.common.exception.AuthException;
 import com.kernel.global.domain.entity.User;
 import com.kernel.global.repository.UserRepository;
 import com.kernel.reservation.common.enums.ReservationErrorCode;
+import com.kernel.reservation.common.enums.ServiceCheckLogErrorCode;
 import com.kernel.reservation.common.exception.ReservationException;
+import com.kernel.reservation.common.exception.ServiceCheckLogException;
 import com.kernel.reservation.domain.entity.ReservationCancel;
 import com.kernel.reservation.domain.entity.ReservationMatch;
+import com.kernel.reservation.domain.entity.ServiceCheckLog;
 import com.kernel.reservation.repository.ManagerReservationRepository;
 import com.kernel.reservation.repository.ReservationMatchRepository;
+import com.kernel.reservation.repository.ServiceCheckLogRepository;
 import com.kernel.reservation.repository.common.ReservationCancelRepository;
 import com.kernel.reservation.service.info.ManagerReservationDetailInfo;
 import com.kernel.reservation.service.info.ManagerReservationSummaryInfo;
+import com.kernel.reservation.service.request.ServiceCheckInReqDTO;
 import com.kernel.reservation.service.request.ManagerReservationSearchCondDTO;
 import com.kernel.reservation.service.request.ReservationCancelReqDTO;
+import com.kernel.reservation.service.request.ServiceCheckOutReqDTO;
+import com.kernel.reservation.service.response.ServiceCheckInRspDTO;
 import com.kernel.reservation.service.response.ManagerReservationRspDTO;
 import com.kernel.reservation.service.response.ManagerReservationSummaryRspDTO;
+import com.kernel.reservation.service.response.ServiceCheckOutRspDTO;
 import com.kernel.sharedDomain.common.enums.MatchStatus;
 import com.kernel.sharedDomain.common.enums.ReservationStatus;
 import com.kernel.sharedDomain.domain.entity.Reservation;
@@ -29,6 +36,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.NoSuchElementException;
+
 @Service
 @RequiredArgsConstructor
 public class ManagerReservationServiceImpl implements ManagerReservationService {
@@ -37,6 +46,7 @@ public class ManagerReservationServiceImpl implements ManagerReservationService 
     private final ManagerReservationRepository managerReservationRepository;
     private final ReservationMatchRepository reservationMatchRepository;
     private final ReservationCancelRepository cancelRepository;
+    private final ServiceCheckLogRepository serviceCheckLogRepository;
 
     /**
      * 매니저에게 할당된 예약 목록 조회 (검색 조건 및 페이징 처리)
@@ -144,5 +154,77 @@ public class ManagerReservationServiceImpl implements ManagerReservationService 
 
         cancelRepository.save(reservationCancelRecord);
 
+    }
+
+    /**
+     * 체크인
+     * @param managerId 매니저ID
+     * @param reservationId 예약ID
+     * @param serviceCheckInReqDTO 체크인요청DTO
+     * @return 체크인 정보를 담은 응답
+     */
+    @Override
+    @Transactional
+    public ServiceCheckInRspDTO checkIn(Long managerId, Long reservationId, ServiceCheckInReqDTO serviceCheckInReqDTO) {
+
+        // 1. 예약 조회
+        Reservation reservation = managerReservationRepository.findById(reservationId)
+                .orElseThrow(() -> new ReservationException(ReservationErrorCode.NOT_FOUND_RESERVATION));
+
+        // 2. 체크인 로그 존재 여부 확인
+        if (serviceCheckLogRepository.existsByReservation_ReservationId(reservationId)) {
+            throw new ServiceCheckLogException(ServiceCheckLogErrorCode.CHECK_IN_ALREADY_EXISTS);
+        }
+
+        // 3. 체크인 로그 생성
+        ServiceCheckLog checkLog = ServiceCheckLog.builder()
+                .reservation(reservation)
+                .build();
+
+        // 4. 체크인 로그 기록
+        checkLog.checkIn(serviceCheckInReqDTO.getInFileId());
+
+        // 5. 체크인 로그 저장
+        serviceCheckLogRepository.save(checkLog);
+
+        // 6. 예약 상태를 IN_PROGRESS로 변경
+        reservation.checkIn();
+
+        // 7. Entity -> ResponseDTO 변환 후, return
+        return ServiceCheckInRspDTO.toDTO(checkLog);
+    }
+
+    /**
+     * 체크아웃
+     * @param managerId 매니저ID
+     * @param reservationId 예약ID
+     * @param cleaningLogCheckOutReqDTO 체크아웃요청DTO
+     * @return 체크아웃 정보를 담은 응답
+     */
+    @Override
+    @Transactional
+    public ServiceCheckOutRspDTO checkOut(Long managerId, Long reservationId, ServiceCheckOutReqDTO cleaningLogCheckOutReqDTO) {
+
+        // 1. 예약 조회
+        Reservation reservation = managerReservationRepository.findById(reservationId)
+                .orElseThrow(() -> new ReservationException(ReservationErrorCode.NOT_FOUND_RESERVATION));
+
+        // 2. 체크인 로그 조회
+        ServiceCheckLog checkLog = serviceCheckLogRepository.findByReservation_ReservationId(reservationId)
+                .orElseThrow(() -> new ServiceCheckLogException(ServiceCheckLogErrorCode.CHECK_IN_NOT_FOUND));
+
+        // 3. 체크아웃 로그 존재 여부 확인
+        if (checkLog.getOutTime() != null) {
+            throw new ServiceCheckLogException(ServiceCheckLogErrorCode.CHECK_OUT_ALREADY_EXISTS);
+        }
+
+        // 4. 체크아웃 로그 기록
+        checkLog.checkOut(cleaningLogCheckOutReqDTO.getOutFileId());
+
+        // 6. 예약 상태를 COMPLETED로 변경
+        reservation.checkOut();
+
+        // 7. Entity -> ResponseDTO 변환 후, return
+        return ServiceCheckOutRspDTO.toDTO(checkLog);
     }
 }

--- a/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationServiceImpl.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationServiceImpl.java
@@ -115,7 +115,7 @@ public class ManagerReservationServiceImpl implements ManagerReservationService 
                 .orElseThrow(() -> new ReservationException(ReservationErrorCode.NOT_FOUND_RESERVATION_MATCH));
 
         // 3. 매니저 수락 처리
-        requestedReservation.managerAccept();
+        requestedReservation.changeStatus(ReservationStatus.CONFIRMED);
 
         // 4. 매니저 예약 매칭 정보 업데이트
         reservationMatch.changeStatus(MatchStatus.MATCHED);
@@ -193,7 +193,7 @@ public class ManagerReservationServiceImpl implements ManagerReservationService 
         serviceCheckLogRepository.save(checkLog);
 
         // 7. 예약 상태를 IN_PROGRESS로 변경
-        reservation.checkIn();
+        reservation.changeStatus(ReservationStatus.IN_PROGRESS);
 
         // 8. Entity -> ResponseDTO 변환 후, return
         return ServiceCheckInRspDTO.toDTO(checkLog);
@@ -227,7 +227,7 @@ public class ManagerReservationServiceImpl implements ManagerReservationService 
         checkLog.checkOut(cleaningLogCheckOutReqDTO.getOutFileId());
 
         // 6. 예약 상태를 COMPLETED로 변경
-        reservation.checkOut();
+        reservation.changeStatus(ReservationStatus.COMPLETED);
 
         // 7. Entity -> ResponseDTO 변환 후, return
         return ServiceCheckOutRspDTO.toDTO(checkLog);

--- a/reservation/src/main/java/com/kernel/reservation/service/request/ServiceCheckInReqDTO.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/request/ServiceCheckInReqDTO.java
@@ -1,0 +1,12 @@
+package com.kernel.reservation.service.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class ServiceCheckInReqDTO {
+
+    // 체크인 첨부파일
+    @NotNull(message = "체크인 첨부파일은 필수입니다.")
+    private Long inFileId;
+}

--- a/reservation/src/main/java/com/kernel/reservation/service/request/ServiceCheckOutReqDTO.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/request/ServiceCheckOutReqDTO.java
@@ -1,0 +1,12 @@
+package com.kernel.reservation.service.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class ServiceCheckOutReqDTO {
+
+    // 체크아웃 첨부파일
+    @NotNull(message = "체크아웃 첨부파일은 필수입니다.")
+    private Long outFileId;
+}

--- a/reservation/src/main/java/com/kernel/reservation/service/response/ServiceCheckInRspDTO.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/response/ServiceCheckInRspDTO.java
@@ -1,0 +1,36 @@
+package com.kernel.reservation.service.response;
+
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+import com.kernel.reservation.domain.entity.ServiceCheckLog;
+import com.kernel.sharedDomain.common.enums.ReservationStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ServiceCheckInRspDTO {
+    // 예약ID
+    private Long reservationId;
+
+    // 체크인 일시
+    private Timestamp inTime;
+
+    // 체크인 첨부파일
+    private Long inFileId;
+
+    // 예약 상태
+    private ReservationStatus status;
+
+    // entity -> DTO
+    public static ServiceCheckInRspDTO toDTO(ServiceCheckLog entity) {
+        return ServiceCheckInRspDTO.builder()
+                .reservationId(entity.getReservation().getReservationId())
+                .inTime(entity.getInTime())
+                .inFileId(entity.getInFileId())
+                .status(entity.getReservation().getStatus())
+                .build();
+    }
+}

--- a/reservation/src/main/java/com/kernel/reservation/service/response/ServiceCheckOutRspDTO.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/response/ServiceCheckOutRspDTO.java
@@ -1,0 +1,37 @@
+package com.kernel.reservation.service.response;
+
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+import com.kernel.reservation.domain.entity.ServiceCheckLog;
+import com.kernel.sharedDomain.common.enums.ReservationStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ServiceCheckOutRspDTO {
+
+    // 예약ID
+    private Long reservationId;
+
+    // 체크아웃 일시
+    private Timestamp outTime;
+
+    // 체크아웃 첨부파일
+    private Long outFileId;
+
+    // 예약 상태
+    private ReservationStatus status;
+
+    // entity -> DTO
+    public static ServiceCheckOutRspDTO toDTO(ServiceCheckLog entity) {
+        return ServiceCheckOutRspDTO.builder()
+                .reservationId(entity.getReservation().getReservationId())
+                .outTime(entity.getOutTime())
+                .outFileId(entity.getOutFileId())
+                .status(entity.getReservation().getStatus())
+                .build();
+    }
+}

--- a/reservation/src/main/java/com/kernel/reservation/service/response/common/ServiceCheckLogErrorRspDTO.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/response/common/ServiceCheckLogErrorRspDTO.java
@@ -1,0 +1,35 @@
+package com.kernel.reservation.service.response.common;
+
+import com.kernel.reservation.common.exception.ServiceCheckLogException;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Schema(description = "서비스 체크 로그 에러 응답 DTO")
+@Builder
+public class ServiceCheckLogErrorRspDTO {
+
+    @Schema(description = "요청 성공 여부", example = "false", required = true)
+    private final boolean success;
+
+    @Schema(description = "에러 코드", example = "400", required = true)
+    private final String code;
+
+    @Schema(description = "에러 메시지", example = "잘못된 요청입니다.", required = true)
+    private final String message;
+
+    @Schema(description = "타임스탬프", example = "2023-10-01T12:00:00", required = true)
+    private final LocalDateTime timestamp;
+
+    public static ServiceCheckLogErrorRspDTO createErrorResponse(ServiceCheckLogException errorCode) {
+        return ServiceCheckLogErrorRspDTO.builder()
+                .success(false)
+                .code(errorCode.getErrorCode().getCode())
+                .message(errorCode.getMessage())
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+}

--- a/shared-domain/src/main/java/com/kernel/sharedDomain/domain/entity/Reservation.java
+++ b/shared-domain/src/main/java/com/kernel/sharedDomain/domain/entity/Reservation.java
@@ -60,9 +60,19 @@ public class Reservation extends BaseEntity {
         // TODO: 상태 변경 사유를 매개변수로 받는데 어떻게 처리할지 결정해야 함
     }
 
+    // 매니저 예약 수락
     public void managerAccept() {
         this.status = ReservationStatus.CONFIRMED;
     }
 
+    // 예약 체크인
+    public void checkIn() {
+        this.status = ReservationStatus.IN_PROGRESS;
+    }
+
+    // 예약 체크아웃
+    public void checkOut() {
+        this.status = ReservationStatus.COMPLETED;
+    }
 
 }

--- a/shared-domain/src/main/java/com/kernel/sharedDomain/domain/entity/Reservation.java
+++ b/shared-domain/src/main/java/com/kernel/sharedDomain/domain/entity/Reservation.java
@@ -60,19 +60,8 @@ public class Reservation extends BaseEntity {
         // TODO: 상태 변경 사유를 매개변수로 받는데 어떻게 처리할지 결정해야 함
     }
 
-    // 매니저 예약 수락
-    public void managerAccept() {
-        this.status = ReservationStatus.CONFIRMED;
+    // 사유 없는 예약 상태 변경
+    public void changeStatus(ReservationStatus reservationStatus) {
+        this.status = reservationStatus;
     }
-
-    // 예약 체크인
-    public void checkIn() {
-        this.status = ReservationStatus.IN_PROGRESS;
-    }
-
-    // 예약 체크아웃
-    public void checkOut() {
-        this.status = ReservationStatus.COMPLETED;
-    }
-
 }


### PR DESCRIPTION
## ✅ 작업 유형

- [x] ♻️ 리팩토링 (Refactor)

---

## 🔍 작업 내용

<!-- 어떤 작업을 했는지 구체적으로 적어주세요 (코드, 로직, 예외 처리 등) -->
- 체크인 / 체크아웃 로직 reservation 모듈로 이동
- 체크인 로직 수정
  1. 체크인을 했지만 체크아웃을 하지 않은 예약이 있으면 다른 체크인을 방지하는 로직 추가
  2. 같은 예약에 중복 체크인을 방지하기 위해 특정 예약과 연관된 ServiceCheckLog 테이블이 있을 경우 체크인 방지
  3. 1 ~ 2단계에서 문제가 없을 때 ServiceCheckLog 테이블 생성 후 체크인 로그 기록 
  4. 예약 상태 수정 - IN_PROGRESS
- 체크 아웃 로직 수정
  1. 특정 예약과 연관된 ServiceCheckLog 테이블을 조회해서 없다면 체크인을 하지 않은 것으로 판단해서 체크아웃 방지
  2. 검색한 ServiceCheckLog에서 체크아웃 로그가 이미 되어있는 여부를 확인해서 중복 체크아웃 방지
  3. 1 ~ 2 단계에서 문제가 없을 때 ServiceCheckLog 테이블에 체크아웃 로그 기록
  4. 예약 상태 수정 - COMPLETED
- 체크인 / 체크아웃 커스텀 예외 핸들러 추가
- 파일 업로드 기능 버그 수정
  - Spring Security에서 파일 업로드 관련 url이 SecurityFilterChain에서 권한 없음으로 판단하고 로그아웃 처리되는 문제를 수정
  - AUTHENTICATED_URLS에 .authenticated가 되어있었지만 JWTFILTER를 filter 수행 전에 실행하는 코드가 없어 JWTFILTER에서 SecurityContextHolder에 인증 정보 객체를 주입하는 과정이 생략됨.
  - 필터링 수행 전 JWTFITLER를 사용한 인증 정보 객체 주입 과정을 추가
---

## 💬 리뷰요청

<!-- 리뷰어가 참고하면 좋을 내용, 고민한 점 등을 자유롭게 작성해주세요 -->
- 체크인 / 체크아웃 로직에 대해서 의문이 들거나 개선할 점이 있다면 리뷰주세요.
- 파일 업로드 요청 url이 Spring SecurityFilterChain에서 필터링 되는 문제가 있습니다. 이 부분에 JWTFILTER를 호출해 인증 절차를 추가했는데 리뷰 부탁드립니다.
- 파일 업로드 기능에 문제가 있어서 수정했습니다. 클라이언트에서 테스트를 할 때 공통 컴포넌트로 사용할 수 있게 만들어 두었습니다. 파일 업로드 로직에 궁금하신 점이 있다면 리뷰주세요.
  - 파일 업로드 절차
    1. 파일 선택 - presigned URL을 요청하는 것부터 fileId를 가져오는 것까지 자동화했습니다.
    2. 게시물 업로드나 체크인/체크아웃 - 이미 업로드 작업을 마친 후 별도로 backend에 파일 업로드 관련 요청을 할 필요가 없습니다. 
---

## 📎 관련 이슈

<!-- 관련된 이슈 번호가 있다면 연결해주세요 -->
Closes #253
