### PR TITLE
[Fix] 매니저 마이페이지 문제 해결

### DIFF
--- a/member/src/main/java/com/kernel/member/common/enums/MemberErrorCode.java
+++ b/member/src/main/java/com/kernel/member/common/enums/MemberErrorCode.java
@@ -11,7 +11,10 @@ public enum MemberErrorCode {
     POINT_EXCEED_LIMIT(400, "POINT-001", "보유 가능한 최대 포인트는 1,000,000원을 초과할 수 없습니다."),
 
     // Specialty 관련
-    SPECIALTY_NOT_FOUND(404, "SPECIALTY-001", "전문 분야를 찾을 수 없습니다.");
+    SPECIALTY_NOT_FOUND(404, "SPECIALTY-001", "전문 분야를 찾을 수 없습니다."),
+
+    // AvailableTime 관련
+    AVAILABLE_TIME_NOT_FOUND(404, "AVAILABLE_TIME-001", "매니저의 근무 가능 시간을 조회할 수 없습니다.");
 
     private final int status;
     private final String code;

--- a/member/src/main/java/com/kernel/member/common/enums/MemberErrorCode.java
+++ b/member/src/main/java/com/kernel/member/common/enums/MemberErrorCode.java
@@ -8,7 +8,10 @@ import lombok.RequiredArgsConstructor;
 public enum MemberErrorCode {
 
     // point 관련
-    POINT_EXCEED_LIMIT(400, "POINT-001", "보유 가능한 최대 포인트는 1,000,000원을 초과할 수 없습니다.");
+    POINT_EXCEED_LIMIT(400, "POINT-001", "보유 가능한 최대 포인트는 1,000,000원을 초과할 수 없습니다."),
+
+    // Specialty 관련
+    SPECIALTY_NOT_FOUND(404, "SPECIALTY-001", "전문 분야를 찾을 수 없습니다.");
 
     private final int status;
     private final String code;

--- a/member/src/main/java/com/kernel/member/common/exception/AvailableTimeException.java
+++ b/member/src/main/java/com/kernel/member/common/exception/AvailableTimeException.java
@@ -1,0 +1,14 @@
+package com.kernel.member.common.exception;
+
+import com.kernel.member.common.enums.MemberErrorCode;
+import lombok.Getter;
+
+@Getter
+public class AvailableTimeException extends RuntimeException {
+
+    private final MemberErrorCode errorCode;
+    public AvailableTimeException(MemberErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/member/src/main/java/com/kernel/member/common/exception/SpecialtyException.java
+++ b/member/src/main/java/com/kernel/member/common/exception/SpecialtyException.java
@@ -1,0 +1,15 @@
+package com.kernel.member.common.exception;
+
+import com.kernel.member.common.enums.MemberErrorCode;
+import lombok.Getter;
+
+@Getter
+public class SpecialtyException extends RuntimeException {
+
+    private final MemberErrorCode errorCode;
+
+    public SpecialtyException(MemberErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/member/src/main/java/com/kernel/member/common/handler/MemberExceptionHandler.java
+++ b/member/src/main/java/com/kernel/member/common/handler/MemberExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.kernel.member.common.handler;
 
 import com.kernel.global.service.dto.response.ApiResponse;
+import com.kernel.member.common.exception.SpecialtyException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +18,13 @@ public class MemberExceptionHandler {
     @ExceptionHandler(PrinterException.class)
     public ResponseEntity<ApiResponse<Void>> handlePrinterException(PrinterException e) {
         log.warn("PrinterException error: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ApiResponse<>(false, e.getMessage(), null));
+    }
+
+    // 특기 예외 처리
+    @ExceptionHandler(SpecialtyException.class)
+    public ResponseEntity<ApiResponse<Void>> handleSpecialtyException(SpecialtyException e) {
+        log.error("SpecialtyException error: {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ApiResponse<>(false, e.getMessage(), null));
     }
 }

--- a/member/src/main/java/com/kernel/member/common/handler/MemberExceptionHandler.java
+++ b/member/src/main/java/com/kernel/member/common/handler/MemberExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.kernel.member.common.handler;
 
 import com.kernel.global.service.dto.response.ApiResponse;
+import com.kernel.member.common.exception.AvailableTimeException;
 import com.kernel.member.common.exception.SpecialtyException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -21,10 +22,16 @@ public class MemberExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ApiResponse<>(false, e.getMessage(), null));
     }
 
-    // 특기 예외 처리
+    // 매니저 회원가입, 매니저 정보 수정 예외 처리
     @ExceptionHandler(SpecialtyException.class)
     public ResponseEntity<ApiResponse<Void>> handleSpecialtyException(SpecialtyException e) {
         log.error("SpecialtyException error: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ApiResponse<>(false, e.getMessage(), null));
+    }
+
+    @ExceptionHandler(AvailableTimeException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAvailableTimeException(AvailableTimeException e) {
+        log.error("AvailableTimeException error: {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ApiResponse<>(false, e.getMessage(), null));
     }
 }

--- a/member/src/main/java/com/kernel/member/domain/entity/Manager.java
+++ b/member/src/main/java/com/kernel/member/domain/entity/Manager.java
@@ -61,9 +61,9 @@ public class Manager {
     private LocalDateTime contractDate;
 
     // Manager 정보 수정
-    public void update(ManagerUpdateInfoReqDTO request) {
-        if (request.getSpecialty() != null) {
-            this.specialty = request.getSpecialty();
+    public void update(ManagerUpdateInfoReqDTO request, ServiceCategory specialty) {
+        if (specialty != null) {
+            this.specialty = specialty;
         }
         if (request.getBio() != null) {
             this.bio = request.getBio();

--- a/member/src/main/java/com/kernel/member/repository/CustomManagerRepositoryImpl.java
+++ b/member/src/main/java/com/kernel/member/repository/CustomManagerRepositoryImpl.java
@@ -200,9 +200,8 @@ public class CustomManagerRepositoryImpl implements CustomManagerRepository{
                 .leftJoin(manager).on(manager.user.eq(user))
                 .leftJoin(managerStatistic).on(managerStatistic.user.eq(user))
                 .leftJoin(managerTermination).on(managerTermination.manager.eq(manager))
-                .leftJoin(availableTime).on(availableTime.manager.eq(manager))
                 .where(user.userId.eq(managerId))
-                .fetchFirst();
+                .fetchOne();
 
         if (adminManagerDetailInfo == null) {
             throw new AuthException(ErrorCode.USER_NOT_FOUND);

--- a/member/src/main/java/com/kernel/member/repository/ManagerTerminationRepository.java
+++ b/member/src/main/java/com/kernel/member/repository/ManagerTerminationRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface ManagerTerminationRepository extends JpaRepository<ManagerTermination, Long> {
-    Optional<ManagerTermination> findByManager(Manager manager);
+    ManagerTermination findByManager(Manager manager);
 }

--- a/member/src/main/java/com/kernel/member/repository/common/ManagerServiceCategoryRepository.java
+++ b/member/src/main/java/com/kernel/member/repository/common/ManagerServiceCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.kernel.member.repository.common;
+
+import com.kernel.sharedDomain.domain.entity.ServiceCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ManagerServiceCategoryRepository extends JpaRepository<ServiceCategory, Long> {
+}

--- a/member/src/main/java/com/kernel/member/service/ManagerServiceImpl.java
+++ b/member/src/main/java/com/kernel/member/service/ManagerServiceImpl.java
@@ -8,6 +8,7 @@ import com.kernel.global.domain.entity.File;
 import com.kernel.global.domain.entity.User;
 import com.kernel.global.repository.FileRepository;
 import com.kernel.member.common.enums.MemberErrorCode;
+import com.kernel.member.common.exception.AvailableTimeException;
 import com.kernel.member.common.exception.SpecialtyException;
 import com.kernel.member.domain.entity.AvailableTime;
 import com.kernel.member.domain.entity.Manager;
@@ -63,6 +64,9 @@ public class ManagerServiceImpl implements ManagerService {
 
         // 4. AvailableTime 저장
         List<AvailableTime> availableTimeList = signupReqDTO.toEntityList(signupReqDTO.getAvailableTimeReqDTOList());
+        if (availableTimeList.isEmpty()) {
+            throw new AvailableTimeException(MemberErrorCode.AVAILABLE_TIME_NOT_FOUND);
+        }
         availableTimeRepository.saveAll(availableTimeList);
 
         // 5. Manager 저장
@@ -132,6 +136,9 @@ public class ManagerServiceImpl implements ManagerService {
 
         // 4. Available Time 조회
         List<AvailableTime> foundAvailableTimeList = availableTimeRepository.findByManager(foundManager);
+        if (foundAvailableTimeList.isEmpty()) {
+            throw new AvailableTimeException(MemberErrorCode.AVAILABLE_TIME_NOT_FOUND);
+        }
 
         // 5. ManagerTermination 조회
         ManagerTermination foundManagerTermination = managerTerminationRepository.findByManager(foundManager);

--- a/member/src/main/java/com/kernel/member/service/ManagerServiceImpl.java
+++ b/member/src/main/java/com/kernel/member/service/ManagerServiceImpl.java
@@ -92,8 +92,7 @@ public class ManagerServiceImpl implements ManagerService {
         List<AvailableTime> foundAvailableTimeList = availableTimeRepository.findByManager(foundManager);
 
         // 5. ManagerTermination 조회
-        ManagerTermination foundManagerTermination = managerTerminationRepository.findByManager(foundManager)
-                .orElseThrow(() -> new NoSuchElementException("매니저 해지 정보가 존재하지 않습니다."));
+        ManagerTermination foundManagerTermination = managerTerminationRepository.findByManager(foundManager);
 
         // 5. 응답 DTO 생성 및 반환
         return ManagerDetailRspDTO.fromInfos(
@@ -130,8 +129,7 @@ public class ManagerServiceImpl implements ManagerService {
         List<AvailableTime> foundAvailableTimeList = availableTimeRepository.findByManager(foundManager);
 
         // ManagerTermination 조회
-        ManagerTermination foundManagerTermination = managerTerminationRepository.findByManager(foundManager)
-                .orElseThrow(() -> new NoSuchElementException("매니저 해지 정보가 존재하지 않습니다."));
+        ManagerTermination foundManagerTermination = managerTerminationRepository.findByManager(foundManager);
 
         // User 수정
         foundUser.updateEmail(updateReqDTO.getUserUpdateReqDTO().getEmail());

--- a/member/src/main/java/com/kernel/member/service/common/info/ManagerTerminationInfo.java
+++ b/member/src/main/java/com/kernel/member/service/common/info/ManagerTerminationInfo.java
@@ -15,6 +15,14 @@ public class ManagerTerminationInfo {
 
     // Entity -> Info 변환 메서드
     public static ManagerTerminationInfo fromEntity(ManagerTermination entity) {
+        if (entity == null) {
+            return ManagerTerminationInfo.builder()
+                    .requestAt(null)
+                    .terminatedAt(null)
+                    .TerminationReason(null)
+                    .build();
+        }
+
         return ManagerTerminationInfo.builder()
                 .requestAt(entity.getRequestAt())
                 .terminatedAt(entity.getTerminatedAt())

--- a/member/src/main/java/com/kernel/member/service/request/AvailableTimeUpdateReqDTO.java
+++ b/member/src/main/java/com/kernel/member/service/request/AvailableTimeUpdateReqDTO.java
@@ -2,6 +2,7 @@ package com.kernel.member.service.request;
 
 import com.kernel.member.common.enums.DayOfWeek;
 import com.kernel.member.domain.entity.AvailableTime;
+import com.kernel.member.domain.entity.Manager;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.AssertTrue;
 import lombok.Builder;
@@ -26,13 +27,14 @@ public class AvailableTimeUpdateReqDTO {
         return dayOfWeek != null ? time != null : true;
     }
 
-    public static AvailableTime toEntity(AvailableTimeUpdateReqDTO availableTimeUpdateReqDTO) {
+    public static AvailableTime toEntity(AvailableTimeUpdateReqDTO availableTimeUpdateReqDTO, Manager manager) {
         if (availableTimeUpdateReqDTO == null) {
             return null;
         }
         return AvailableTime.builder()
                 .dayOfWeek(availableTimeUpdateReqDTO.getDayOfWeek())
                 .time(availableTimeUpdateReqDTO.getTime())
+                .manager(manager)
                 .build();
     }
 }

--- a/member/src/main/java/com/kernel/member/service/request/ManagerUpdateInfoReqDTO.java
+++ b/member/src/main/java/com/kernel/member/service/request/ManagerUpdateInfoReqDTO.java
@@ -1,6 +1,5 @@
 package com.kernel.member.service.request;
 
-import com.kernel.sharedDomain.domain.entity.ServiceCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
@@ -12,7 +11,7 @@ import lombok.Getter;
 public class ManagerUpdateInfoReqDTO {
 
     @Schema(description = "특기", example = "HAIR_CUTTING", required = true)
-    private ServiceCategory specialty;
+    private Long specialty;
 
     @Schema(description = "한 줄 소개", example = "전문 헤어 디자이너입니다.", required = true, maxLength = 50)
     @Size(max = 50, message = "한 줄 소개는 최대 50자까지 입력 가능합니다.")

--- a/member/src/main/java/com/kernel/member/service/request/ManagerUpdateReqDTO.java
+++ b/member/src/main/java/com/kernel/member/service/request/ManagerUpdateReqDTO.java
@@ -1,6 +1,7 @@
 package com.kernel.member.service.request;
 
 import com.kernel.member.domain.entity.AvailableTime;
+import com.kernel.member.domain.entity.Manager;
 import com.kernel.member.service.common.request.UserInfoUpdateReqDTO;
 import com.kernel.member.service.common.request.UserUpdateReqDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -33,9 +34,9 @@ public class ManagerUpdateReqDTO {
 
     @Builder
     @Schema(description = "가능 시간 목록을 엔티티 리스트로 변환")
-    public static List<AvailableTime> toEntityList(List<AvailableTimeUpdateReqDTO> availableTimeReqDTOList) {
+    public static List<AvailableTime> toEntityList(List<AvailableTimeUpdateReqDTO> availableTimeReqDTOList, Manager manager) {
         return availableTimeReqDTOList.stream()
-                .map(AvailableTimeUpdateReqDTO::toEntity)
+                .map(availableTimeUpdateReqDTO -> AvailableTimeUpdateReqDTO.toEntity(availableTimeUpdateReqDTO, manager))
                 .toList();
     }
 }

--- a/member/src/main/java/com/kernel/member/service/response/ManagerDetailRspDTO.java
+++ b/member/src/main/java/com/kernel/member/service/response/ManagerDetailRspDTO.java
@@ -100,11 +100,11 @@ public class ManagerDetailRspDTO {
                 .profileImagePath(managerDetailInfo.getProfileImageFilePath() != null ? managerDetailInfo.getProfileImageFilePath() : "")
                 .filePaths(managerDetailInfo.getFilePaths() != null ? managerDetailInfo.getFilePaths() : "")
                 .status(userAccountInfo.getStatus())
-                .contractAt(managerDetailInfo.getContractDate())
+                .contractAt(managerDetailInfo.getContractDate() != null ? managerDetailInfo.getContractDate() : LocalDateTime.now())
                 .availableTimes(availableTimes)
-                .requestedAt(managerTerminationInfo.getRequestAt())
-                .terminationReason(managerTerminationInfo.getTerminationReason())
-                .terminatedAt(managerTerminationInfo.getTerminatedAt())
+                .requestedAt(managerTerminationInfo.getRequestAt() != null ? managerTerminationInfo.getRequestAt() : null)
+                .terminationReason(managerTerminationInfo.getTerminationReason() != null ? managerTerminationInfo.getTerminationReason() : "")
+                .terminatedAt(managerTerminationInfo.getTerminatedAt() != null ? managerTerminationInfo.getTerminatedAt() : null)
                 .build();
     }
 }


### PR DESCRIPTION
## ✅ 작업 유형

- [x] 🐛 버그 수정 (Bug Fix)

---

## 🔍 작업 내용

<!-- 어떤 작업을 했는지 구체적으로 적어주세요 (코드, 로직, 예외 처리 등) -->
- 매니저 상세 정보 조회시 해지 테이블이 null인 상태에서 entity로 build하지 못하는 문제 수정
- 매니저 정보 업데이트 시 specialty에 ServiceCategory를 입력하기 위한 ServiceCategory 조회 및 매핑 로직 추가
- 매니저 정보 업데이트 시 AvailableTime entity를 빌드할 때 매니저 정보 누락 해결

---

## 💬 리뷰요청

<!-- 리뷰어가 참고하면 좋을 내용, 고민한 점 등을 자유롭게 작성해주세요 -->
- 매니저 마이페이지에서 정보 조회와 수정이 되지 않는 문제를 수정했습니다. 매니저 업데이트 로직에 대해서 리뷰 부탁드립니다.

---

## 📎 관련 이슈

<!-- 관련된 이슈 번호가 있다면 연결해주세요 -->
Closes #258 
