### PR TITLE
[Refactor]: 매니저 체크인 / 체크아웃 시 필수였던 파일 id를 선택사항으로 수정

### DIFF
--- a/reservation/src/main/java/com/kernel/reservation/domain/entity/ServiceCheckLog.java
+++ b/reservation/src/main/java/com/kernel/reservation/domain/entity/ServiceCheckLog.java
@@ -34,7 +34,8 @@ public class ServiceCheckLog extends BaseEntity {
     private Timestamp inTime;
 
     // 체크인 파일 ID
-    @Column(nullable = false)
+    //@Column(nullable = false)
+    @Column(nullable = true) // 이슈 테스트 - 체크인 파일은 필수로 하지 않음
     private Long inFileId;
 
     // 체크아웃 시간

--- a/reservation/src/main/java/com/kernel/reservation/service/request/ServiceCheckInReqDTO.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/request/ServiceCheckInReqDTO.java
@@ -7,6 +7,6 @@ import lombok.Getter;
 public class ServiceCheckInReqDTO {
 
     // 체크인 첨부파일
-    @NotNull(message = "체크인 첨부파일은 필수입니다.")
+    //@NotNull(message = "체크인 첨부파일은 필수입니다.")
     private Long inFileId;
 }

--- a/reservation/src/main/java/com/kernel/reservation/service/request/ServiceCheckOutReqDTO.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/request/ServiceCheckOutReqDTO.java
@@ -7,6 +7,6 @@ import lombok.Getter;
 public class ServiceCheckOutReqDTO {
 
     // 체크아웃 첨부파일
-    @NotNull(message = "체크아웃 첨부파일은 필수입니다.")
+    //@NotNull(message = "체크아웃 첨부파일은 필수입니다.")
     private Long outFileId;
 }


### PR DESCRIPTION
## ✅ 작업 유형

- [x] ♻️ 리팩토링 (Refactor)

---

## 🔍 작업 내용
- 매니저가 체크인 / 체크아웃 시 **첨부파일의 fileId를 요청에 반드시 포함해야 했던 부분을 선택 사항으로 수정**
- 첨부파일이 없는 경우에도 정상적으로 체크인 / 체크아웃 요청이 가능하도록 변경

---

## 💬 리뷰 요청
- 로컬에서 프론트엔드와 테스트를 완료했습니다.
- 필수 → 선택 변경으로 인해 기존 로직에 영향이 없는지 확인 부탁드립니다.

---

## 📎 관련 이슈
Closes #277