### PR TITLE
[Feature] 매니저/수요자 예약 수 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+	// 낙관적 락을 사용하기 위한 의존성
+	implementation 'org.springframework.retry:spring-retry'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
+
 	// Testing dependencies
 	//testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	//testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'

--- a/global/build.gradle
+++ b/global/build.gradle
@@ -23,6 +23,10 @@ dependencies {
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
+    // 낙관적 락을 사용하기 위한 의존성
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+
     // Springdoc OpenAPI for Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 

--- a/member/build.gradle
+++ b/member/build.gradle
@@ -27,6 +27,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // 낙관적 락을 위한 의존성
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/member/src/main/java/com/kernel/member/common/enums/MemberStatisticErrorCode.java
+++ b/member/src/main/java/com/kernel/member/common/enums/MemberStatisticErrorCode.java
@@ -10,7 +10,7 @@ public enum MemberStatisticErrorCode {
     // 통계 관련
     CUSTOMER_STATISTIC_NOT_FOUND(404, "STATISTIC-001", "고객 통계 정보를 찾을 수 없습니다."),
     MANAGER_STATISTIC_NOT_FOUND(404, "STATISTIC-002", "매니저 통계 정보를 찾을 수 없습니다."),
-    CONCURRENT_UPDATE_ERROR(409, "STATISTIC-003", "동시 업데이트 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+    CONCURRENT_UPDATE_ERROR(409, "STATISTIC-003", "요청이 정상적으로 처리되지 않았습니다. 잠시 후 다시 시도해주세요.");
 
     private final int status;
     private final String code;

--- a/member/src/main/java/com/kernel/member/common/enums/MemberStatisticErrorCode.java
+++ b/member/src/main/java/com/kernel/member/common/enums/MemberStatisticErrorCode.java
@@ -9,7 +9,8 @@ public enum MemberStatisticErrorCode {
 
     // 통계 관련
     CUSTOMER_STATISTIC_NOT_FOUND(404, "STATISTIC-001", "고객 통계 정보를 찾을 수 없습니다."),
-    MANAGER_STATISTIC_NOT_FOUND(404, "STATISTIC-002", "매니저 통계 정보를 찾을 수 없습니다.");
+    MANAGER_STATISTIC_NOT_FOUND(404, "STATISTIC-002", "매니저 통계 정보를 찾을 수 없습니다."),
+    CONCURRENT_UPDATE_ERROR(409, "STATISTIC-003", "동시 업데이트 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
 
     private final int status;
     private final String code;

--- a/member/src/main/java/com/kernel/member/common/enums/MemberStatisticErrorCode.java
+++ b/member/src/main/java/com/kernel/member/common/enums/MemberStatisticErrorCode.java
@@ -1,0 +1,17 @@
+package com.kernel.member.common.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum MemberStatisticErrorCode {
+
+    // 통계 관련
+    CUSTOMER_STATISTIC_NOT_FOUND(404, "STATISTIC-001", "고객 통계 정보를 찾을 수 없습니다."),
+    MANAGER_STATISTIC_NOT_FOUND(404, "STATISTIC-002", "매니저 통계 정보를 찾을 수 없습니다.");
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/member/src/main/java/com/kernel/member/common/exception/MemberStatisticException.java
+++ b/member/src/main/java/com/kernel/member/common/exception/MemberStatisticException.java
@@ -1,0 +1,14 @@
+package com.kernel.member.common.exception;
+
+import com.kernel.member.common.enums.MemberStatisticErrorCode;
+import lombok.Getter;
+
+@Getter
+public class MemberStatisticException extends RuntimeException {
+    private final MemberStatisticErrorCode errorCode;
+
+    public MemberStatisticException(MemberStatisticErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/member/src/main/java/com/kernel/member/common/handler/MemberExceptionHandler.java
+++ b/member/src/main/java/com/kernel/member/common/handler/MemberExceptionHandler.java
@@ -2,6 +2,7 @@ package com.kernel.member.common.handler;
 
 import com.kernel.global.service.dto.response.ApiResponse;
 import com.kernel.member.common.exception.AvailableTimeException;
+import com.kernel.member.common.exception.MemberStatisticException;
 import com.kernel.member.common.exception.SpecialtyException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -29,9 +30,17 @@ public class MemberExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ApiResponse<>(false, e.getMessage(), null));
     }
 
+    // 매니저 근무 가능 시간 예외 처리
     @ExceptionHandler(AvailableTimeException.class)
     public ResponseEntity<ApiResponse<Void>> handleAvailableTimeException(AvailableTimeException e) {
         log.error("AvailableTimeException error: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ApiResponse<>(false, e.getMessage(), null));
+    }
+
+    // 사용자 통계 테이블 예외 처리
+    @ExceptionHandler(MemberStatisticException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMemberStatisticException(MemberStatisticException e) {
+        log.error("MemberStatisticException error: {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ApiResponse<>(false, e.getMessage(), null));
     }
 }

--- a/member/src/main/java/com/kernel/member/domain/entity/CustomerStatistic.java
+++ b/member/src/main/java/com/kernel/member/domain/entity/CustomerStatistic.java
@@ -3,6 +3,7 @@ package com.kernel.member.domain.entity;
 import com.kernel.global.domain.entity.BaseEntity;
 import com.kernel.global.domain.entity.User;
 import jakarta.persistence.*;
+import jakarta.validation.Valid;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
@@ -18,6 +19,10 @@ public class CustomerStatistic  extends BaseEntity {
 
     @Id
     private Long userId;
+
+    // 동시성 제어를 위한 버전 필드
+    @Version
+    private Long version;
 
     @OneToOne(fetch = FetchType.LAZY)
     @MapsId  // PK이자 FK

--- a/member/src/main/java/com/kernel/member/domain/entity/CustomerStatistic.java
+++ b/member/src/main/java/com/kernel/member/domain/entity/CustomerStatistic.java
@@ -39,4 +39,10 @@ public class CustomerStatistic  extends BaseEntity {
     @Builder.Default
     private Integer reservationCount = 0;
 
+    // 고객의 예약수 업데이트
+    // count를 받는 이유는 예약상태가 "COMPLETED"로 바뀌었을 때 1추가하고 환불처리되었을 때 -1을 하기 위함
+    public void updateReservationCount(Integer count) {
+        this.reservationCount += count;
+    }
+
 }

--- a/member/src/main/java/com/kernel/member/domain/entity/ManagerStatistic.java
+++ b/member/src/main/java/com/kernel/member/domain/entity/ManagerStatistic.java
@@ -20,6 +20,10 @@ public class ManagerStatistic extends BaseEntity {
     @Id
     private Long userId;
 
+    // 동시성 제어를 위한 버전 필드
+    @Version
+    private Long version;
+
     @OneToOne(fetch = FetchType.LAZY)
     @MapsId
     @JoinColumn(name = "user_id")

--- a/member/src/main/java/com/kernel/member/domain/entity/ManagerStatistic.java
+++ b/member/src/main/java/com/kernel/member/domain/entity/ManagerStatistic.java
@@ -39,4 +39,10 @@ public class ManagerStatistic extends BaseEntity {
     @Column(precision = 2, scale = 1)
     @Builder.Default
     private BigDecimal averageRating = BigDecimal.ZERO;
+
+    // 매니저의 예약수 업데이트
+    // count를 받는 이유는 예약상태가 "COMPLETED"로 바뀌었을 때 1추가하고 환불처리되었을 때 -1을 하기 위함
+    public void updateReservationCount(Integer count) {
+        this.reservationCount += count;
+    }
 }

--- a/member/src/main/java/com/kernel/member/repository/CustomerStatisticRepository.java
+++ b/member/src/main/java/com/kernel/member/repository/CustomerStatisticRepository.java
@@ -2,6 +2,12 @@ package com.kernel.member.repository;
 
 import com.kernel.member.domain.entity.CustomerStatistic;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CustomerStatisticRepository extends JpaRepository<CustomerStatistic, Long> {
+
+    @Modifying
+    @Query("UPDATE CustomerStatistic cs SET cs.reservationCount = cs.reservationCount + :count WHERE cs.userId = :userId")
+    void updateReservationCount(Long userId, Integer count);
 }

--- a/member/src/main/java/com/kernel/member/repository/CustomerStatisticRepository.java
+++ b/member/src/main/java/com/kernel/member/repository/CustomerStatisticRepository.java
@@ -6,8 +6,4 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface CustomerStatisticRepository extends JpaRepository<CustomerStatistic, Long> {
-
-    @Modifying
-    @Query("UPDATE CustomerStatistic cs SET cs.reservationCount = cs.reservationCount + :count WHERE cs.userId = :userId")
-    void updateReservationCount(Long userId, Integer count);
 }

--- a/member/src/main/java/com/kernel/member/repository/ManagerStatisticRepository.java
+++ b/member/src/main/java/com/kernel/member/repository/ManagerStatisticRepository.java
@@ -6,8 +6,4 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface ManagerStatisticRepository extends JpaRepository<ManagerStatistic, Long> {
-
-    @Modifying
-    @Query("UPDATE ManagerStatistic ms SET ms.reservationCount = ms.reservationCount + :count WHERE ms.userId = :userId")
-    void updateReservationCount(Long userId, Integer count);
 }

--- a/member/src/main/java/com/kernel/member/repository/ManagerStatisticRepository.java
+++ b/member/src/main/java/com/kernel/member/repository/ManagerStatisticRepository.java
@@ -2,6 +2,12 @@ package com.kernel.member.repository;
 
 import com.kernel.member.domain.entity.ManagerStatistic;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ManagerStatisticRepository extends JpaRepository<ManagerStatistic, Long> {
+
+    @Modifying
+    @Query("UPDATE ManagerStatistic ms SET ms.reservationCount = ms.reservationCount + :count WHERE ms.userId = :userId")
+    void updateReservationCount(Long userId, Integer count);
 }

--- a/reservation/build.gradle
+++ b/reservation/build.gradle
@@ -30,6 +30,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // 낙관적 락을 위한 의존성
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/reservation/src/main/java/com/kernel/reservation/common/enums/ServiceCheckLogErrorCode.java
+++ b/reservation/src/main/java/com/kernel/reservation/common/enums/ServiceCheckLogErrorCode.java
@@ -17,6 +17,7 @@ public enum ServiceCheckLogErrorCode {
     CHECK_OUT_FILE_UPLOAD_FAILED(500, "SERVICE-CHECK-LOG-8", "체크아웃 첨부파일 업로드에 실패했습니다."),
     CHECK_IN_NOT_ALLOWED(400, "SERVICE-CHECK-LOG-9", "체크아웃을 하지 않은 예약이 존재합니다.");
 
+
     private final int status;
     private final String code;
     private final String message;

--- a/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationServiceImpl.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationServiceImpl.java
@@ -5,6 +5,7 @@ import com.kernel.global.common.enums.UserRole;
 import com.kernel.global.common.exception.AuthException;
 import com.kernel.global.domain.entity.User;
 import com.kernel.global.repository.UserRepository;
+import com.kernel.member.repository.CustomerStatisticRepository;
 import com.kernel.member.repository.ManagerStatisticRepository;
 import com.kernel.reservation.common.enums.ReservationErrorCode;
 import com.kernel.reservation.common.enums.ServiceCheckLogErrorCode;
@@ -51,6 +52,7 @@ public class ManagerReservationServiceImpl implements ManagerReservationService 
     private final UserRepository userRepository;
     private final ManagerReservationRepository managerReservationRepository;
     private final ManagerStatisticRepository managerStatisticRepository;
+    private final CustomerStatisticRepository customerStatisticRepository;
     private final ReservationMatchRepository reservationMatchRepository;
     private final ReservationCancelRepository cancelRepository;
     private final ServiceCheckLogRepository serviceCheckLogRepository;
@@ -250,8 +252,9 @@ public class ManagerReservationServiceImpl implements ManagerReservationService 
         // 6. 예약 상태를 COMPLETED로 변경
         reservation.changeStatus(ReservationStatus.COMPLETED);
 
-        // 7. 예약 완료 후 매니저 통계 업데이트
+        // 7. 예약 완료 후 매니저 / 수요자 통계 업데이트
         managerStatisticRepository.updateReservationCount(managerId, 1);
+        customerStatisticRepository.updateReservationCount(reservation.getUser().getUserId(), 1);
 
         // 7. Entity -> ResponseDTO 변환 후, return
         return ServiceCheckOutRspDTO.toDTO(checkLog);

--- a/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationServiceImpl.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationServiceImpl.java
@@ -256,15 +256,13 @@ public class ManagerReservationServiceImpl implements ManagerReservationService 
         // 6. 예약 상태를 COMPLETED로 변경
         reservation.changeStatus(ReservationStatus.COMPLETED);
 
-        // 7. 예약 완료 후 매니저 / 수요자 통계 업데이트
-        managerStatisticRepository.updateReservationCount(managerId, 1);
-        customerStatisticRepository.updateReservationCount(reservation.getUser().getUserId(), 1);
-
+        // 7. 예약 완료 후 매니저
         ManagerStatistic managerStatistic = managerStatisticRepository.findById(managerId)
                 .orElseThrow(() -> new MemberStatisticException(MemberStatisticErrorCode.MANAGER_STATISTIC_NOT_FOUND));
 
         managerStatistic.updateReservationCount(1);
 
+        // 8. 수요자 통계 업데이트
         CustomerStatistic customerStatistic = customerStatisticRepository.findById(reservation.getUser().getUserId())
                 .orElseThrow(() -> new MemberStatisticException(MemberStatisticErrorCode.CUSTOMER_STATISTIC_NOT_FOUND));
 

--- a/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationServiceImpl.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationServiceImpl.java
@@ -5,6 +5,10 @@ import com.kernel.global.common.enums.UserRole;
 import com.kernel.global.common.exception.AuthException;
 import com.kernel.global.domain.entity.User;
 import com.kernel.global.repository.UserRepository;
+import com.kernel.member.common.enums.MemberStatisticErrorCode;
+import com.kernel.member.common.exception.MemberStatisticException;
+import com.kernel.member.domain.entity.CustomerStatistic;
+import com.kernel.member.domain.entity.ManagerStatistic;
 import com.kernel.member.repository.CustomerStatisticRepository;
 import com.kernel.member.repository.ManagerStatisticRepository;
 import com.kernel.reservation.common.enums.ReservationErrorCode;
@@ -255,6 +259,16 @@ public class ManagerReservationServiceImpl implements ManagerReservationService 
         // 7. 예약 완료 후 매니저 / 수요자 통계 업데이트
         managerStatisticRepository.updateReservationCount(managerId, 1);
         customerStatisticRepository.updateReservationCount(reservation.getUser().getUserId(), 1);
+
+        ManagerStatistic managerStatistic = managerStatisticRepository.findById(managerId)
+                .orElseThrow(() -> new MemberStatisticException(MemberStatisticErrorCode.MANAGER_STATISTIC_NOT_FOUND));
+
+        managerStatistic.updateReservationCount(1);
+
+        CustomerStatistic customerStatistic = customerStatisticRepository.findById(reservation.getUser().getUserId())
+                .orElseThrow(() -> new MemberStatisticException(MemberStatisticErrorCode.CUSTOMER_STATISTIC_NOT_FOUND));
+
+        customerStatistic.updateReservationCount(1);
 
         // 7. Entity -> ResponseDTO 변환 후, return
         return ServiceCheckOutRspDTO.toDTO(checkLog);

--- a/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationServiceImpl.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationServiceImpl.java
@@ -281,6 +281,7 @@ public class ManagerReservationServiceImpl implements ManagerReservationService 
      * 매니저 통계 업데이트
      * @param managerStatistic 매니저 통계 엔티티
      * @param count 예약 수 (1 또는 -1)
+     * OptimisticLockException 발생 시 재시도 0.05초 간격으로 최대 5회 재시도
      */
     @Retryable(
             value = OptimisticLockException.class,
@@ -292,6 +293,13 @@ public class ManagerReservationServiceImpl implements ManagerReservationService 
         managerStatistic.updateReservationCount(count);
     }
 
+    /**
+     * OptimisticLockException 발생 시 복구 메소드
+     * @param e OptimisticLockException 예외 객체
+     * @param managerStatistic 매니저 통계 엔티티
+     * @param count 예약 수 (1 또는 -1)
+     * recover에 파라미터를 사용하지 않아도 메서드에 포함한 이유는 recover가 동작할 때 파라미터를 사용해 문제가 발생한 메서드를 구분하기 때문
+     */
     @Recover
     private void recover(OptimisticLockException e, ManagerStatistic managerStatistic, Integer count) {
         throw new MemberStatisticException(MemberStatisticErrorCode.CONCURRENT_UPDATE_ERROR);
@@ -301,6 +309,7 @@ public class ManagerReservationServiceImpl implements ManagerReservationService 
      * 고객 통계 업데이트
      * @param customerStatistic 고객 통계 엔티티
      * @param count 예약 수 (1 또는 -1)
+     * OptimisticLockException 발생 시 재시도 0.05초 간격으로 최대 5회 재시도
      */
     @Retryable(
             value = OptimisticLockException.class,
@@ -312,6 +321,13 @@ public class ManagerReservationServiceImpl implements ManagerReservationService 
         customerStatistic.updateReservationCount(count);
     }
 
+    /**
+     * OptimisticLockException 발생 시 복구 메소드
+     * @param e OptimisticLockException 예외 객체
+     * @param customerStatistic 고객 통계 엔티티
+     * @param count 예약 수 (1 또는 -1)
+     * recover에 파라미터를 사용하지 않아도 메서드에 포함한 이유는 recover가 동작할 때 파라미터를 사용해 문제가 발생한 메서드를 구분하기 때문
+     */
     @Recover
     private void recover(OptimisticLockException e, CustomerStatistic customerStatistic, Integer count) {
         throw new MemberStatisticException(MemberStatisticErrorCode.CONCURRENT_UPDATE_ERROR);

--- a/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationServiceImpl.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationServiceImpl.java
@@ -5,6 +5,7 @@ import com.kernel.global.common.enums.UserRole;
 import com.kernel.global.common.exception.AuthException;
 import com.kernel.global.domain.entity.User;
 import com.kernel.global.repository.UserRepository;
+import com.kernel.member.repository.ManagerStatisticRepository;
 import com.kernel.reservation.common.enums.ReservationErrorCode;
 import com.kernel.reservation.common.enums.ServiceCheckLogErrorCode;
 import com.kernel.reservation.common.exception.ReservationException;
@@ -49,6 +50,7 @@ public class ManagerReservationServiceImpl implements ManagerReservationService 
 
     private final UserRepository userRepository;
     private final ManagerReservationRepository managerReservationRepository;
+    private final ManagerStatisticRepository managerStatisticRepository;
     private final ReservationMatchRepository reservationMatchRepository;
     private final ReservationCancelRepository cancelRepository;
     private final ServiceCheckLogRepository serviceCheckLogRepository;
@@ -247,6 +249,9 @@ public class ManagerReservationServiceImpl implements ManagerReservationService 
 
         // 6. 예약 상태를 COMPLETED로 변경
         reservation.changeStatus(ReservationStatus.COMPLETED);
+
+        // 7. 예약 완료 후 매니저 통계 업데이트
+        managerStatisticRepository.updateReservationCount(managerId, 1);
 
         // 7. Entity -> ResponseDTO 변환 후, return
         return ServiceCheckOutRspDTO.toDTO(checkLog);

--- a/reservation/src/main/java/com/kernel/reservation/service/StatisticUpdateService.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/StatisticUpdateService.java
@@ -1,0 +1,59 @@
+package com.kernel.reservation.service;
+
+import com.kernel.member.common.enums.MemberStatisticErrorCode;
+import com.kernel.member.common.exception.MemberStatisticException;
+import com.kernel.member.domain.entity.CustomerStatistic;
+import com.kernel.member.domain.entity.ManagerStatistic;
+import jakarta.persistence.OptimisticLockException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StatisticUpdateService {
+
+    /**
+     * 매니저 통계 업데이트
+     * @param managerStatistic 매니저 통계 엔티티
+     * @param count 예약 수 (1 또는 -1)
+     * OptimisticLockException 발생 시 재시도 0.05초 간격으로 최대 5회 재시도
+     */
+    @Retryable(
+            value = OptimisticLockException.class,
+            maxAttempts = 5,
+            backoff = @Backoff(delay = 50)
+    )
+    @Transactional
+    public void updateManagerStatistic(ManagerStatistic managerStatistic, Integer count) {
+        managerStatistic.updateReservationCount(count);
+    }
+
+
+    /**
+     * 고객 통계 업데이트
+     * @param customerStatistic 고객 통계 엔티티
+     * @param count 예약 수 (1 또는 -1)
+     * OptimisticLockException 발생 시 재시도 0.05초 간격으로 최대 5회 재시도
+     */
+    @Retryable(
+            value = OptimisticLockException.class,
+            maxAttempts = 5,
+            backoff = @Backoff(delay = 50)
+    )
+    @Transactional
+    public void updateCustomerStatistic(CustomerStatistic customerStatistic, Integer count) {
+        customerStatistic.updateReservationCount(count);
+    }
+
+    /**
+     * 통계 업데이트 실패 시 복구 메서드 (매니저/고객 통합)
+     */
+    @Recover
+    public void recover(OptimisticLockException e, Object statistic, Integer count) {
+        throw new MemberStatisticException(MemberStatisticErrorCode.CONCURRENT_UPDATE_ERROR);
+    }
+}

--- a/src/main/java/com/kernel/ApiApplication.java
+++ b/src/main/java/com/kernel/ApiApplication.java
@@ -7,6 +7,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.retry.annotation.EnableRetry;
 
 @SpringBootApplication(scanBasePackages = "com.kernel")
 @EnableJpaRepositories(basePackages = "com.kernel")
@@ -15,6 +16,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
         JwtProperties.class,
         AwsProperties.class
 })
+@EnableRetry
 public class ApiApplication {
 
     public static void main(String[] args) {


### PR DESCRIPTION
## ✅ 작업 유형

- [x] ✨ 기능 추가 (Feature)

---

## 🔍 작업 내용
- 매니저가 체크아웃을 하면 예약 상태가 "COMPLETED" 바뀌는 것을 매니저의 업무 완료를 판단하는 기준으로 사용
- 매니저 체크아웃 완료 시 매니저 통계 테이블과 수요자 통계 테이블의 예약수를 1 증가하는 쿼리 추가
- 수요자 역시 통계 테이블에 예약수가 있으므로 매니저의 체크아웃 수행시 예약수를 1 증가하는 쿼리 추가
---

## 💬 리뷰요청

<!-- 리뷰어가 참고하면 좋을 내용, 고민한 점 등을 자유롭게 작성해주세요 -->
- 수요자도 통계 테이블에 예약수가 있어서 매니저가 체크아웃할 때 함께 예약 수를 1증가 했는데 적절한 동작인지 리뷰 부탁드립니다.

- 통계 데이터를 업데이트할 때 ManagerStatistic entity를 메모리에 적재하지 않고 update 쿼리를 사용해서 바로 매니저의 예약수를 업데이트 했습니다.
단순 통계 업데이트를 수행할 때는 이렇게 벌크 업데이트로 구현하는 것이 메모리 효율이 적고 성능 DB에서 직접 수행해서 속도가 빠르다는 장점이 있습니다.
하지만 entity를 로드할 때 사용할 수 있는 JPA 기능을 활용하지 못해 Auditing을 사용할 수 없고 낙관적 락을 체크를 하지 않는 문제가 있습니다. 

- 제 생각에는 1만 더해주는 로직에 entity의 모든 필드를 메모리에 적재해서 update를 수행하는 것이 리소스 낭비라고 생각해서 벌크 업데이트를 사용했는데 기존 방식처럼 entity를 로드해서 사용하는 것이 더 좋을지 아니면 벌크 업데이트가 나을지 리뷰 부탁드립니다.
---

## 📎 관련 이슈

<!-- 관련된 이슈 번호가 있다면 연결해주세요 -->
Closes #270
