### PR TITLE
[Feature] 수요자 / 매니저 리뷰 등록시 통계 테이블 반영 기능 추가

### DIFF
--- a/evaluation/build.gradle
+++ b/evaluation/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     // Module dependencies
     implementation project(':global')
     implementation project(':shared-domain')
+    implementation project(':member')
 
     // Spring Boot dependencies
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/evaluation/build.gradle
+++ b/evaluation/build.gradle
@@ -28,6 +28,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // 낙관적 락을 사용하기 위한 의존성
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/evaluation/src/main/java/com/kernel/evaluation/service/review/CustomerReviewServiceImpl.java
+++ b/evaluation/src/main/java/com/kernel/evaluation/service/review/CustomerReviewServiceImpl.java
@@ -8,6 +8,7 @@ import com.kernel.evaluation.repository.review.CustomerReviewRepository;
 import com.kernel.evaluation.service.review.dto.request.ReviewCreateReqDTO;
 import com.kernel.evaluation.service.review.dto.request.ReviewUpdateReqDTO;
 import com.kernel.evaluation.service.review.dto.response.CustomerReviewRspDTO;
+import com.kernel.member.repository.ManagerStatisticRepository;
 import com.kernel.sharedDomain.common.enums.ReservationStatus;
 import com.kernel.sharedDomain.domain.entity.Reservation;
 import com.kernel.sharedDomain.service.ReservationQueryPort;
@@ -30,6 +31,7 @@ public class CustomerReviewServiceImpl implements CustomerReviewService {
 
     private final CustomerReviewRepository customerReviewRepository;
     private final ReservationQueryPort reservationQueryPort;
+    private final ManagerStatisticRepository managerStatisticRepository;
 
     /**
      * 수요자 리뷰 목록 조회
@@ -113,6 +115,11 @@ public class CustomerReviewServiceImpl implements CustomerReviewService {
 
         // 4. 리뷰 정보 조회
         CustomerReviewInfo reviewInfo = customerReviewRepository.getCustomerReviewsByReservationId(userId, reservationId);
+
+        // 5. 매니저 통계 업데이트
+        if (reviewInfo != null) {
+            managerStatisticRepository.updateReviewCount(scheduleAndMatchInfo.getManagerId());
+        }
 
         return CustomerReviewRspDTO.fromInfo(reviewInfo, scheduleAndMatchInfo);
     }

--- a/evaluation/src/main/java/com/kernel/evaluation/service/review/CustomerReviewServiceImpl.java
+++ b/evaluation/src/main/java/com/kernel/evaluation/service/review/CustomerReviewServiceImpl.java
@@ -8,6 +8,9 @@ import com.kernel.evaluation.repository.review.CustomerReviewRepository;
 import com.kernel.evaluation.service.review.dto.request.ReviewCreateReqDTO;
 import com.kernel.evaluation.service.review.dto.request.ReviewUpdateReqDTO;
 import com.kernel.evaluation.service.review.dto.response.CustomerReviewRspDTO;
+import com.kernel.member.common.enums.MemberStatisticErrorCode;
+import com.kernel.member.common.exception.MemberStatisticException;
+import com.kernel.member.domain.entity.ManagerStatistic;
 import com.kernel.member.repository.ManagerStatisticRepository;
 import com.kernel.sharedDomain.common.enums.ReservationStatus;
 import com.kernel.sharedDomain.domain.entity.Reservation;
@@ -32,6 +35,7 @@ public class CustomerReviewServiceImpl implements CustomerReviewService {
     private final CustomerReviewRepository customerReviewRepository;
     private final ReservationQueryPort reservationQueryPort;
     private final ManagerStatisticRepository managerStatisticRepository;
+    private final EvaluationStatisticUpdateService evaluationStatisticUpdateService;
 
     /**
      * 수요자 리뷰 목록 조회
@@ -117,9 +121,10 @@ public class CustomerReviewServiceImpl implements CustomerReviewService {
         CustomerReviewInfo reviewInfo = customerReviewRepository.getCustomerReviewsByReservationId(userId, reservationId);
 
         // 5. 매니저 통계 업데이트
-        if (reviewInfo != null) {
-            managerStatisticRepository.updateReviewCount(scheduleAndMatchInfo.getManagerId());
-        }
+        ManagerStatistic managerStatistic = managerStatisticRepository.findById(scheduleAndMatchInfo.getManagerId())
+                .orElseThrow(() -> new MemberStatisticException(MemberStatisticErrorCode.MANAGER_STATISTIC_NOT_FOUND));
+
+        evaluationStatisticUpdateService.updateManagerReviewStatistic(managerStatistic);
 
         return CustomerReviewRspDTO.fromInfo(reviewInfo, scheduleAndMatchInfo);
     }

--- a/evaluation/src/main/java/com/kernel/evaluation/service/review/EvaluationStatisticUpdateService.java
+++ b/evaluation/src/main/java/com/kernel/evaluation/service/review/EvaluationStatisticUpdateService.java
@@ -1,0 +1,14 @@
+package com.kernel.evaluation.service.review;
+
+import com.kernel.member.domain.entity.CustomerStatistic;
+import com.kernel.member.domain.entity.ManagerStatistic;
+import jakarta.persistence.OptimisticLockException;
+
+public interface EvaluationStatisticUpdateService {
+
+    void updateManagerReviewStatistic(ManagerStatistic managerStatistic);
+
+    void updateCustomerReviewStatistic(CustomerStatistic customerStatistic);
+
+    void recover(OptimisticLockException e, Object statistic);
+}

--- a/evaluation/src/main/java/com/kernel/evaluation/service/review/EvaluationStatisticUpdateServiceImpl.java
+++ b/evaluation/src/main/java/com/kernel/evaluation/service/review/EvaluationStatisticUpdateServiceImpl.java
@@ -1,0 +1,58 @@
+package com.kernel.evaluation.service.review;
+
+import com.kernel.member.common.enums.MemberStatisticErrorCode;
+import com.kernel.member.common.exception.MemberStatisticException;
+import com.kernel.member.domain.entity.CustomerStatistic;
+import com.kernel.member.domain.entity.ManagerStatistic;
+import jakarta.persistence.OptimisticLockException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class EvaluationStatisticUpdateServiceImpl implements EvaluationStatisticUpdateService {
+
+    /**
+     * 매니저 리뷰 통계 업데이트
+     * @param managerStatistic 매니저 통계 엔티티
+     *
+     */
+    @Retryable(
+            value = OptimisticLockException.class,
+            maxAttempts = 5,
+            backoff = @Backoff(delay = 50)
+    )
+    @Override
+    @Transactional
+    public void updateManagerReviewStatistic(ManagerStatistic managerStatistic) {
+        managerStatistic.updateReviewCount();
+    }
+
+    /**
+     * 고객 리뷰 통계 업데이트
+     * @param customerStatistic 고객 통계 엔티티
+     */
+    @Retryable(
+            value = OptimisticLockException.class,
+            maxAttempts = 5,
+            backoff = @Backoff(delay = 50)
+    )
+    @Override
+    @Transactional
+    public void updateCustomerReviewStatistic(CustomerStatistic customerStatistic) {
+        customerStatistic.updateReviewCount();
+    }
+
+    /**
+     * 통계 업데이트 실패 시 복구 메서드 (매니저/고객 통합)
+     */
+    @Override
+    @Recover
+    public void recover(OptimisticLockException e, Object statistic) {
+        throw new MemberStatisticException(MemberStatisticErrorCode.CONCURRENT_UPDATE_ERROR);
+    }
+}

--- a/member/src/main/java/com/kernel/member/domain/entity/CustomerStatistic.java
+++ b/member/src/main/java/com/kernel/member/domain/entity/CustomerStatistic.java
@@ -50,4 +50,9 @@ public class CustomerStatistic  extends BaseEntity {
         this.reservationCount += count;
     }
 
+    // 고객의 리뷰수 업데이트
+    public void updateReviewCount() {
+        this.reviewCount += 1;
+    }
+
 }

--- a/member/src/main/java/com/kernel/member/domain/entity/ManagerStatistic.java
+++ b/member/src/main/java/com/kernel/member/domain/entity/ManagerStatistic.java
@@ -49,4 +49,9 @@ public class ManagerStatistic extends BaseEntity {
     public void updateReservationCount(Integer count) {
         this.reservationCount += count;
     }
+
+    // 매니저의 리뷰수 업데이트
+    public void updateReviewCount() {
+        this.reviewCount += 1;
+    }
 }

--- a/member/src/main/java/com/kernel/member/repository/CustomerStatisticRepository.java
+++ b/member/src/main/java/com/kernel/member/repository/CustomerStatisticRepository.java
@@ -2,6 +2,11 @@ package com.kernel.member.repository;
 
 import com.kernel.member.domain.entity.CustomerStatistic;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CustomerStatisticRepository extends JpaRepository<CustomerStatistic, Long> {
+    @Modifying(clearAutomatically = true) // 영속성 컨텍스트를 자동으로 초기화하여 변경 사항을 반영
+    @Query("UPDATE CustomerStatistic cs SET cs.reviewCount = cs.reviewCount + 1 WHERE cs.user.id = :userId")
+    void updateReviewCount(Long userId);
 }

--- a/member/src/main/java/com/kernel/member/repository/ManagerStatisticRepository.java
+++ b/member/src/main/java/com/kernel/member/repository/ManagerStatisticRepository.java
@@ -2,6 +2,11 @@ package com.kernel.member.repository;
 
 import com.kernel.member.domain.entity.ManagerStatistic;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ManagerStatisticRepository extends JpaRepository<ManagerStatistic, Long> {
+    @Modifying(clearAutomatically = true) // 영속성 컨텍스트를 자동으로 초기화하여 변경 사항을 반영
+    @Query("UPDATE ManagerStatistic ms SET ms.reviewCount = ms.reviewCount + 1 WHERE ms.user.id = :userId")
+    void updateReviewCount(Long userId);
 }

--- a/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationServiceImpl.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/ManagerReservationServiceImpl.java
@@ -38,7 +38,6 @@ import com.kernel.sharedDomain.common.enums.ReservationStatus;
 import com.kernel.sharedDomain.domain.entity.Reservation;
 
 import com.kernel.sharedDomain.domain.entity.ServiceCategory;
-import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -48,7 +47,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -62,7 +60,7 @@ public class ManagerReservationServiceImpl implements ManagerReservationService 
     private final ReservationCancelRepository cancelRepository;
     private final ServiceCheckLogRepository serviceCheckLogRepository;
     private final ServiceCategoryRepository serviceCategoryRepository;
-    private final StatisticUpdateService statisticUpdateService;
+    private final ReservationStatisticUpdateService reservationStatisticUpdateService;
 
     /**
      * 매니저에게 할당된 예약 목록 조회 (검색 조건 및 페이징 처리)
@@ -262,16 +260,16 @@ public class ManagerReservationServiceImpl implements ManagerReservationService 
         ManagerStatistic managerStatistic = managerStatisticRepository.findById(managerId)
                 .orElseThrow(() -> new MemberStatisticException(MemberStatisticErrorCode.MANAGER_STATISTIC_NOT_FOUND));
 
-        statisticUpdateService.updateManagerStatistic(managerStatistic, 1);
+        reservationStatisticUpdateService.updateManagerReservationStatistic(managerStatistic, 1);
 
 
         // 8. 수요자 통계 업데이트
         CustomerStatistic customerStatistic = customerStatisticRepository.findById(reservation.getUser().getUserId())
                 .orElseThrow(() -> new MemberStatisticException(MemberStatisticErrorCode.CUSTOMER_STATISTIC_NOT_FOUND));
 
-        statisticUpdateService.updateCustomerStatistic(customerStatistic, 1);
+        reservationStatisticUpdateService.updateCustomerReservationStatistic(customerStatistic, 1);
 
-        // 7. Entity -> ResponseDTO 변환 후, return
+        // 9. Entity -> ResponseDTO 변환 후, return
         return ServiceCheckOutRspDTO.toDTO(checkLog);
     }
 }

--- a/reservation/src/main/java/com/kernel/reservation/service/ReservationStatisticUpdateService.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/ReservationStatisticUpdateService.java
@@ -1,0 +1,14 @@
+package com.kernel.reservation.service;
+
+import com.kernel.member.domain.entity.CustomerStatistic;
+import com.kernel.member.domain.entity.ManagerStatistic;
+import jakarta.persistence.OptimisticLockException;
+
+public interface ReservationStatisticUpdateService {
+
+    void updateManagerReservationStatistic(ManagerStatistic managerStatistic, Integer count);
+
+    void updateCustomerReservationStatistic(CustomerStatistic customerStatistic, Integer count);
+
+    void recover(OptimisticLockException e, Object statistic, Integer count);
+}

--- a/reservation/src/main/java/com/kernel/reservation/service/ReservationStatisticUpdateServiceImpl.java
+++ b/reservation/src/main/java/com/kernel/reservation/service/ReservationStatisticUpdateServiceImpl.java
@@ -14,10 +14,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class StatisticUpdateService {
+public class ReservationStatisticUpdateServiceImpl implements ReservationStatisticUpdateService{
 
     /**
-     * 매니저 통계 업데이트
+     * 매니저 예약 통계 업데이트
      * @param managerStatistic 매니저 통계 엔티티
      * @param count 예약 수 (1 또는 -1)
      * OptimisticLockException 발생 시 재시도 0.05초 간격으로 최대 5회 재시도
@@ -27,14 +27,15 @@ public class StatisticUpdateService {
             maxAttempts = 5,
             backoff = @Backoff(delay = 50)
     )
+    @Override
     @Transactional
-    public void updateManagerStatistic(ManagerStatistic managerStatistic, Integer count) {
+    public void updateManagerReservationStatistic(ManagerStatistic managerStatistic, Integer count) {
         managerStatistic.updateReservationCount(count);
     }
 
 
     /**
-     * 고객 통계 업데이트
+     * 고객 예약 통계 업데이트
      * @param customerStatistic 고객 통계 엔티티
      * @param count 예약 수 (1 또는 -1)
      * OptimisticLockException 발생 시 재시도 0.05초 간격으로 최대 5회 재시도
@@ -44,8 +45,9 @@ public class StatisticUpdateService {
             maxAttempts = 5,
             backoff = @Backoff(delay = 50)
     )
+    @Override
     @Transactional
-    public void updateCustomerStatistic(CustomerStatistic customerStatistic, Integer count) {
+    public void updateCustomerReservationStatistic(CustomerStatistic customerStatistic, Integer count) {
         customerStatistic.updateReservationCount(count);
     }
 
@@ -53,6 +55,7 @@ public class StatisticUpdateService {
      * 통계 업데이트 실패 시 복구 메서드 (매니저/고객 통합)
      */
     @Recover
+    @Override
     public void recover(OptimisticLockException e, Object statistic, Integer count) {
         throw new MemberStatisticException(MemberStatisticErrorCode.CONCURRENT_UPDATE_ERROR);
     }


### PR DESCRIPTION
## ✅ 작업 유형

- [x] ✨ 기능 추가 (Feature)

---

## 🔍 작업 내용
- 수요자가 리뷰 등록시 매니저 통계 테이블의 리뷰수 1 증가 쿼리 추가
- 매니저가 리뷰 등록시 수요자 통계 테이블의 리뷰수 1 증가 쿼리 추가

---

## 💬 리뷰요청
- 통계 테이블의 예약수 반영할 때와 동일하게 벌크 업데이트를 사용했습니다. 벌크 업데이트 사용에 대한 리뷰 부탁드립니다.

---

## 📎 관련 이슈

<!-- 관련된 이슈 번호가 있다면 연결해주세요 -->
Closes #269 
