### PR TITLE
[Refactor] 관리자 계정 업데이트 수정 및 오류 수정

### DIFF
--- a/admin/src/main/java/com/kernel/admin/controller/AdminController.java
+++ b/admin/src/main/java/com/kernel/admin/controller/AdminController.java
@@ -2,6 +2,7 @@ package com.kernel.admin.controller;
 
 import com.kernel.admin.service.AdminService;
 import com.kernel.admin.service.dto.request.AdminSearchReqDTO;
+import com.kernel.admin.service.dto.request.AdminUpdateReqDTO;
 import com.kernel.admin.service.dto.response.AdminDetailRspDTO;
 import com.kernel.admin.service.dto.response.AdminSearchRspDTO;
 import com.kernel.global.domain.entity.User;
@@ -63,15 +64,15 @@ public class AdminController {
      * 관리자 정보 수정 API
      *
      * @param userId      수정할 관리자 ID
-     * @param updateReqDTO 관리자 정보 수정 요청 DTO
+     * @param request 관리자 정보 수정 요청 DTO
      * @return 수정된 관리자 정보가 포함된 ApiResponse 객체
      */
     @PatchMapping("/{userId}")
     public ResponseEntity<ApiResponse<AdminDetailRspDTO>> updateAdmin(
             @PathVariable Long userId,
-            @RequestBody @Valid UserUpdateReqDTO updateReqDTO
-    ) {
-        AdminDetailRspDTO updatedAdmin = adminService.updateAdmin(userId, updateReqDTO);
+            @RequestBody @Valid AdminUpdateReqDTO request
+            ) {
+        AdminDetailRspDTO updatedAdmin = adminService.updateAdmin(userId, request);
         return ResponseEntity.ok(new ApiResponse<>(true, "관리자 정보 수정 성공", updatedAdmin));
     }
 

--- a/admin/src/main/java/com/kernel/admin/repository/CustomAdminRepositoryImpl.java
+++ b/admin/src/main/java/com/kernel/admin/repository/CustomAdminRepositoryImpl.java
@@ -25,7 +25,6 @@ public class CustomAdminRepositoryImpl implements CustomAdminRepository {
     @Override
     public Page<AdminUserSearchInfo> searchByConditionsWithPaging(AdminUserSearchCondition request, Pageable pageable) {
         QUser user = QUser.user;
-
         // 전체 개수
         Long total = Optional.ofNullable(
                 queryFactory
@@ -35,7 +34,7 @@ public class CustomAdminRepositoryImpl implements CustomAdminRepository {
                                 user.userName.containsIgnoreCase(request.getUserName() != null ? request.getUserName() : ""),
                                 user.email.containsIgnoreCase(request.getEmail() != null ? request.getEmail() : ""),
                                 user.phone.containsIgnoreCase(request.getPhone() != null ? request.getPhone() : ""),
-                                user.status.eq(request.getStatus() != null ? request.getStatus() : UserStatus.ACTIVE),
+                                request.getStatus() != null && !request.getStatus().isEmpty() ? user.status.in(request.getStatus()) : null,
                                 user.role.eq(UserRole.ADMIN) // 관리자만 조회
                         )
                         .fetchOne()
@@ -56,7 +55,7 @@ public class CustomAdminRepositoryImpl implements CustomAdminRepository {
                         user.userName.containsIgnoreCase(request.getUserName() != null ? request.getUserName() : ""),
                         user.email.containsIgnoreCase(request.getEmail() != null ? request.getEmail() : ""),
                         user.phone.containsIgnoreCase(request.getPhone() != null ? request.getPhone() : ""),
-                        user.status.eq(request.getStatus() != null ? request.getStatus() : UserStatus.ACTIVE),
+                        request.getStatus() != null && !request.getStatus().isEmpty() ? user.status.in(request.getStatus()) : null,
                         user.role.eq(UserRole.ADMIN)
                 )
                 .offset(pageable.getOffset())

--- a/admin/src/main/java/com/kernel/admin/service/AdminService.java
+++ b/admin/src/main/java/com/kernel/admin/service/AdminService.java
@@ -1,6 +1,7 @@
 package com.kernel.admin.service;
 
 import com.kernel.admin.service.dto.request.AdminSearchReqDTO;
+import com.kernel.admin.service.dto.request.AdminUpdateReqDTO;
 import com.kernel.admin.service.dto.response.AdminDetailRspDTO;
 import com.kernel.admin.service.dto.response.AdminSearchRspDTO;
 import com.kernel.member.service.common.request.UserSignupReqDTO;
@@ -18,7 +19,7 @@ public interface AdminService {
     Page<AdminSearchRspDTO> searchAdminList(AdminSearchReqDTO request, Pageable pageable);
 
     // 관리자 정보 수정
-    AdminDetailRspDTO updateAdmin(Long userId, UserUpdateReqDTO updateReqDTO);
+    AdminDetailRspDTO updateAdmin(Long userId, AdminUpdateReqDTO request);
 
     // 관리자 정보 삭제
     void deleteAdmin(Long userId);

--- a/admin/src/main/java/com/kernel/admin/service/AdminServiceImpl.java
+++ b/admin/src/main/java/com/kernel/admin/service/AdminServiceImpl.java
@@ -13,7 +13,6 @@ import com.kernel.global.service.dto.condition.AdminUserSearchCondition;
 import com.kernel.member.service.common.UserService;
 import com.kernel.member.service.common.info.UserAccountInfo;
 import com.kernel.member.service.common.request.UserSignupReqDTO;
-import com.kernel.member.service.common.request.UserUpdateReqDTO;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -57,9 +56,7 @@ public class AdminServiceImpl implements AdminService {
     @Transactional(readOnly = true)
     public Page<AdminSearchRspDTO> searchAdminList(AdminSearchReqDTO request, Pageable pageable) {
         AdminUserSearchCondition adminUserSearchCondition = request.toCondition();
-
         Page<AdminUserSearchInfo> adminPage = adminRepository.searchByConditionsWithPaging(adminUserSearchCondition, pageable);
-
 
         return AdminSearchRspDTO.fromInfo(adminPage);
     }
@@ -117,6 +114,12 @@ public class AdminServiceImpl implements AdminService {
          adminRepository.save(foundAdmin);
     }
 
+    /**
+     * 전화번호 업데이트 시 중복 검사
+     *
+     * @param currentPhone 현재 전화번호
+     * @param newPhone 새 전화번호
+     */
     private void validatePhoneUpdate(String currentPhone, String newPhone) {
         // null이거나 공백인 경우 검사하지 않음
         if (newPhone == null || newPhone.isBlank()) return;

--- a/admin/src/main/java/com/kernel/admin/service/AdminServiceImpl.java
+++ b/admin/src/main/java/com/kernel/admin/service/AdminServiceImpl.java
@@ -73,7 +73,7 @@ public class AdminServiceImpl implements AdminService {
     public AdminDetailRspDTO updateAdmin(Long userId, AdminUpdateReqDTO request) {
 
         // 1. admin User 조회
-        User foundAdmin = userService.getByUserIdAndStatus(userId, UserStatus.ACTIVE);
+        User foundAdmin = userService.getByUserIdAndStatus(request.getAdminId(), UserStatus.ACTIVE);
 
         // 2. phone 중복 검사
         validatePhoneUpdate(foundAdmin.getPhone(), request.getPhone());

--- a/admin/src/main/java/com/kernel/admin/service/dto/request/AdminSearchReqDTO.java
+++ b/admin/src/main/java/com/kernel/admin/service/dto/request/AdminSearchReqDTO.java
@@ -6,8 +6,12 @@ import com.kernel.global.service.dto.condition.AdminUserSearchCondition;
 import jakarta.validation.constraints.Max;
 import lombok.Getter;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Setter;
+
+import java.util.List;
 
 @Getter
+@Setter
 @Schema(description = "관리자 검색 요청 DTO")
 public class AdminSearchReqDTO {
 
@@ -24,7 +28,7 @@ public class AdminSearchReqDTO {
     private String email;
 
     @Schema(description = "사용자 상태", example = "ACTIVE")
-    private UserStatus status; // UserStatus enum의 이름을 문자열로 받음
+    private List<UserStatus> status; // UserStatus enum의 이름을 문자열로 받음
 
     // AdminUserSearchCondition에서 사용되는 필드들 매핑
     public AdminUserSearchCondition toCondition() {

--- a/admin/src/main/java/com/kernel/admin/service/dto/request/AdminUpdateReqDTO.java
+++ b/admin/src/main/java/com/kernel/admin/service/dto/request/AdminUpdateReqDTO.java
@@ -1,11 +1,17 @@
 package com.kernel.admin.service.dto.request;
 
+import com.kernel.member.service.common.request.UserResetPwdReqDTO;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
 public class AdminUpdateReqDTO {
+    // 관리자 ID
+    @NotNull(message = "관리자 ID는 필수 입력값입니다.")
+    private Long adminId;
 
     // 관리자 이름
     @Size(max = 10, message = "이름은 10자 이하로 입력해주세요.")
@@ -19,7 +25,7 @@ public class AdminUpdateReqDTO {
     @Size(max = 50, message = "이메일은 최대 50자까지 입력 가능합니다.")
     private String email;
 
-    // 관리자 비밀번호
-    private String password;
-
+    // 관리자 비밀번호 변경 요청 DTO
+    @Valid
+    UserResetPwdReqDTO resetPwd; // 비밀번호 변경 요청 DTO
 }

--- a/global/src/main/java/com/kernel/global/common/enums/ErrorCode.java
+++ b/global/src/main/java/com/kernel/global/common/enums/ErrorCode.java
@@ -15,7 +15,7 @@ public enum ErrorCode implements ErrorCodeInterface {
     // 로그인 관련
     INVALID_CREDENTIALS(401, "AUTH003", "아이디 또는 비밀번호가 올바르지 않습니다."),
     ACCOUNT_LOCKED(401, "AUTH004", "계정이 잠겨있습니다."),
-    INVALID_PASSWORD(401, "AUTH005", "비밀번호가 올바르지 않습니다."),
+    INVALID_PASSWORD(400, "AUTH005", "비밀번호가 올바르지 않습니다."),
 
     // JWT 토큰 관련
     INVALID_TOKEN(401, "JWT001", "유효하지 않은 토큰입니다."),

--- a/global/src/main/java/com/kernel/global/common/enums/ErrorCode.java
+++ b/global/src/main/java/com/kernel/global/common/enums/ErrorCode.java
@@ -23,7 +23,7 @@ public enum ErrorCode implements ErrorCodeInterface {
     REFRESH_TOKEN_NOT_FOUND(401, "JWT003", "리프레시 토큰을 찾을 수 없습니다."),
 
     // 권한 관련
-    ACCESS_DENIED(403, "AUTH005", "접근 권한이 없습니다."),
+    ACCESS_DENIED(403, "AUTH007", "접근 권한이 없습니다."),
 
     // 서버 에러
     INTERNAL_SERVER_ERROR(500, "SRV001", "서버 내부 오류가 발생했습니다.");

--- a/global/src/main/java/com/kernel/global/domain/entity/User.java
+++ b/global/src/main/java/com/kernel/global/domain/entity/User.java
@@ -46,11 +46,6 @@ public class User extends BaseEntity {
     @Builder.Default
     private UserStatus status = UserStatus.ACTIVE;
 
-    // 테스트 계정 플래그
-    @Column(nullable = false)
-    @Builder.Default
-    private Boolean testAccount = false;
-
     // 사용자 email 수정
     public void updateEmail(String email) {
         if(!email.isBlank() && !this.email.equals(email)) {

--- a/global/src/main/java/com/kernel/global/domain/entity/User.java
+++ b/global/src/main/java/com/kernel/global/domain/entity/User.java
@@ -46,8 +46,28 @@ public class User extends BaseEntity {
     @Builder.Default
     private UserStatus status = UserStatus.ACTIVE;
 
+    // 테스트 계정 플래그
+    @Column(nullable = false)
+    @Builder.Default
+    private Boolean testAccount = false;
+
     // 사용자 email 수정
     public void updateEmail(String email) {
+        if(!email.isBlank() && !this.email.equals(email)) {
+            this.email = email;
+        }
+    }
+
+    // 관리자 계정 업데이트
+    public void updateAdmin(String phone, String userName, String email) {
+        // 전화번호는 고유키이므로 서비스 단에서 중복 검사 필수
+        if(!phone.isBlank() && !this.phone.equals(phone)) {
+            this.phone = phone;
+        }
+
+        if(!userName.isBlank() && !this.userName.equals(userName)) {
+            this.userName = userName;
+        }
         if(!email.isBlank() && !this.email.equals(email)) {
             this.email = email;
         }

--- a/global/src/main/java/com/kernel/global/domain/info/AdminUserSearchInfo.java
+++ b/global/src/main/java/com/kernel/global/domain/info/AdminUserSearchInfo.java
@@ -7,7 +7,8 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PUBLIC) // TODO: AccessLevel.PROTECTED일 때 문제가 되는 원인 파악
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class AdminUserSearchInfo {
     private Long userId;
     private String userName;

--- a/global/src/main/java/com/kernel/global/service/dto/condition/AdminUserSearchCondition.java
+++ b/global/src/main/java/com/kernel/global/service/dto/condition/AdminUserSearchCondition.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.List;
+
 @Getter
 @Builder
 @Schema(description = "관리자 사용자 검색 조건 DTO")
@@ -25,5 +27,5 @@ public class AdminUserSearchCondition {
     private String email;
 
     @Schema(description = "사용자 상태", example = "ACTIVE")
-    private UserStatus status;
+    private List<UserStatus> status;
 }

--- a/member/src/main/java/com/kernel/member/domain/entity/CustomerStatistic.java
+++ b/member/src/main/java/com/kernel/member/domain/entity/CustomerStatistic.java
@@ -22,7 +22,8 @@ public class CustomerStatistic  extends BaseEntity {
 
     // 동시성 제어를 위한 버전 필드
     @Version
-    private Long version;
+    @Builder.Default
+    private Long version = 0L;
 
     @OneToOne(fetch = FetchType.LAZY)
     @MapsId  // PK이자 FK

--- a/member/src/main/java/com/kernel/member/domain/entity/ManagerStatistic.java
+++ b/member/src/main/java/com/kernel/member/domain/entity/ManagerStatistic.java
@@ -22,7 +22,8 @@ public class ManagerStatistic extends BaseEntity {
 
     // 동시성 제어를 위한 버전 필드
     @Version
-    private Long version;
+    @Builder.Default
+    private Long version = 0L;
 
     @OneToOne(fetch = FetchType.LAZY)
     @MapsId


### PR DESCRIPTION
## ✅ 작업 유형

- [x] ♻️ 리팩토링 (Refactor)

---

## 🔍 작업 내용
- 기존 이메일만 변경 가능했던 관리자 계정 업데이트 기능을 이름, 전화번호, 이메일, 비밀번호 모두 변경하도록 수정
- 낙관적 락을 위해 사용한 version 필드에 기본값 0을 설정
- 쿼리 수행시 요청이 DTO에 매핑이 되지 않는 문제 해결

---

## 💬 리뷰요청
- 관리자가 업데이트 할 수 있는 항목을 이름, 전화번호, 이메일, 비밀번호로 늘렸습니다.
- 전화번호가 고유키라서 바꾸지 못 하도록 막으려고 했지만 이슈 테스트때 전화번호도 변경할 수 있게 해달라는 요청이 있어 중복검사 후 변경이 가능하도록 수정했습니다.
- 비밀번호 변경과 같은 로직은 기존에 작성되어 있던 코드를 재사용했습니다.

---

## 📎 관련 이슈

<!-- 관련된 이슈 번호가 있다면 연결해주세요 -->
Closes #283
