### PR TITLE
[Hotfix] Dockerfile logback 설정 오류 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ WORKDIR /app
 COPY --from=build /workspace/build/libs/*.jar app.jar
 
 # 실행 시 외부 설정(application.yml) 지정
-ENTRYPOINT ["java", "-jar", "app.jar", "--spring.config.location=file:/config/application.yml", "--spring.config.location=file:/config/logback-spring.xml"]
+ENTRYPOINT ["java", "-jar", "app.jar", "--spring.config.location=file:/config/application.yml", "--logging.config=file:/config/logback-spring.xml"]


### PR DESCRIPTION
## ✅ 작업 유형

- [x] 🐛 버그 수정 (Bug Fix)

---

## 🔍 작업 내용
- Dockerfile logback 구성 수정
  - "--spring.config.location"=file:/config/logback-spring.xml" 구문을 "--logging.config=file:/config/logback-spring.xml"]으로 수정

---

## 💬 리뷰요청
- Dockerfile에서 springboot app을 실행시키는 명령어의 옵션에 오류가 있었습니다. 로그 관련한 옵션은 --spring.config가 아니라 --logging.config를 사용해야했습니다. 이 부분을 수정했습니다.

---

## 📎 관련 이슈

<!-- 관련된 이슈 번호가 있다면 연결해주세요 -->
Closes #293 
