### PR TITLE
Fix: 기존 사용자 소셜 로그인시 role을 조회한 사용자의 role을 응답하도록 수정

### DIFF
--- a/global/src/main/java/com/kernel/global/service/CustomOAuth2UserServiceImpl.java
+++ b/global/src/main/java/com/kernel/global/service/CustomOAuth2UserServiceImpl.java
@@ -110,7 +110,7 @@ public class CustomOAuth2UserServiceImpl implements CustomOAuth2UserService {
                 existingUser.getPhone(),
                 existingUser.getUserId(),
                 existingUser.getUserName(),
-                role.toUpperCase(),
+                userOptional.get().getRole().toString(),
                 existingUser.getStatus(),
                 provider
             );


### PR DESCRIPTION
## ✅ 작업 유형

- [x] 🐛 버그 수정 (Bug Fix)

---

## 🔍 작업 내용
- 기존 사용자 소셜 로그인시 role을 조회한 사용자의 role을 응답하도록 수정

---

## 💬 리뷰요청
- 페이지 접속 권한이 없는 사용자가 소셜 로그인 했을 때 로그인이 가능한 오류를 수정했습니다.

---

## 📎 관련 이슈

<!-- 관련된 이슈 번호가 있다면 연결해주세요 -->
Closes #213
