### PR TITLE
fix : 수요자 예약 조회시 매니저명 검색 수정

### DIFF
--- a/reservation/src/main/java/com/kernel/reservation/repository/CustomCustomerReservationRepositoryImpl.java
+++ b/reservation/src/main/java/com/kernel/reservation/repository/CustomCustomerReservationRepositoryImpl.java
@@ -78,7 +78,6 @@ public class CustomCustomerReservationRepositoryImpl implements CustomCustomerRe
                 .leftJoin(location).on(location.reservation.eq(reservation))
                 .leftJoin(schedule).on(schedule.reservation.eq(reservation))
                 .leftJoin(match).on(match.reservation.eq(reservation))
-                .leftJoin(user).on(match.manager.eq(user))
                 .leftJoin(review).on(
                         review.reservation.eq(reservation),
                         review.authorId.eq(userId),
@@ -324,7 +323,7 @@ public class CustomCustomerReservationRepositoryImpl implements CustomCustomerRe
     private BooleanExpression managerNameContains(String keyword) {
         return (keyword != null && !keyword.isBlank())
                 ? match.manager.userName.contains(keyword)
-                .and(reservation.user.role.eq(UserRole.MANAGER))
+                .and(match.manager.role.eq(UserRole.MANAGER))
                 : null;
     }
 }


### PR DESCRIPTION
## ✅ 작업 유형

- [x] 🐛 버그 수정 (Bug Fix)

---

## 🔍 작업 내용
- 수요자 예약 조회시 매니저명 검색 조건 변경 

---

## 💬 리뷰요청
- 기존 이름 조건이 예약한 수요자에 걸려 있어 조회가 되지 않는 문제가 있었습니다.
- 매칭 매니저의 이름으로 조건 번경하였습니다.

---

## 📎 관련 이슈
Closes #303 
